### PR TITLE
Suppress error dialog

### DIFF
--- a/Keysharp.Core/Core/Accessors.cs
+++ b/Keysharp.Core/Core/Accessors.cs
@@ -2291,7 +2291,7 @@
 		public static object A_SuspendExempt
 		{
 			get => Script.TheScript.HotstringManager.hsSuspendExempt;
-			set => Script.TheScript.HotstringManager.hsSuspendExempt = value.Ab();
+			set => Script.TheScript.HotstringManager.hsSuspendExempt = ForceBool(value);
 		}
 
 		/// <summary>

--- a/Keysharp.Core/Core/Errors.cs
+++ b/Keysharp.Core/Core/Errors.cs
@@ -50,11 +50,12 @@
 					err.Processed = true;
 				}
 
-				if (!err.Handled && !script.SuppressErrorOccurredDialog)
+				if (!err.Handled)
 				{
 					err.Handled = true;
 					err.Processed = true;
-					return ErrorDialog.Show(err) != ErrorDialog.ErrorDialogResult.Continue;
+					if (!script.SuppressErrorOccurredDialog)
+						return ErrorDialog.Show(err) != ErrorDialog.ErrorDialogResult.Continue;
 				}
 			}
 

--- a/Keysharp.Core/Core/Flow.cs
+++ b/Keysharp.Core/Core/Flow.cs
@@ -1,3 +1,5 @@
+using Keysharp.Core.Common.Cryptography;
+using Keysharp.Scripting;
 using static Keysharp.Core.Errors;
 
 using Timer1 = System.Timers.Timer;
@@ -682,7 +684,7 @@ namespace Keysharp.Core
 				if (!kserr.Processed)
 					_ = ErrorOccurred(kserr, kserr.ExcType);
 
-				if (!kserr.Handled)
+				if (!kserr.Handled && !TheScript.SuppressErrorOccurredDialog)
 				{
 					var (__pushed, __btv) = t.BeginThread();
 					_ = ErrorDialog.Show(kserr, false);
@@ -710,14 +712,14 @@ namespace Keysharp.Core
 					if (!kserr.Processed)
 						_ = ErrorOccurred(kserr, kserr.ExcType);
 
-					if (!kserr.Handled)
+					if (!kserr.Handled && !TheScript.SuppressErrorOccurredDialog)
 					{
 						var (__pushed, __btv) = t.BeginThread();
 						_ = ErrorDialog.Show(kserr, false);
 						_ = t.EndThread((__pushed, __btv));
 					}
 				}
-				else
+				else if (!TheScript.SuppressErrorOccurredDialog)
 				{
 					var (__pushed, __btv) = t.BeginThread();
 					_ = ErrorDialog.Show(ex);

--- a/Keysharp.Core/Scripting/Script/Script.cs
+++ b/Keysharp.Core/Scripting/Script/Script.cs
@@ -34,7 +34,7 @@ namespace Keysharp.Scripting
 		public bool WinActivateForce = false;
 		//Some unit tests use try..catch in non-script code, which causes ErrorOccurred to display the error dialog.
 		//This allows to suppress it, but only inside ErrorOccurred (not in TryCatch etc).
-		public bool SuppressErrorOccurredDialog = false;
+		public bool SuppressErrorOccurredDialog = AppDomain.CurrentDomain.FriendlyName == "testhost";
 		internal const double DefaultErrorDouble = double.NaN;
 		internal const int DefaultErrorInt = int.MinValue;
 		internal const long DefaultErrorLong = long.MinValue;

--- a/Keysharp.Tests/TestRunner.cs
+++ b/Keysharp.Tests/TestRunner.cs
@@ -13,7 +13,6 @@ namespace Keysharp.Tests
 		public void SetupBeforeEachTest()
 		{
 			s = new Script();
-			s.SuppressErrorOccurredDialog = true;
 			hsm = s.HotstringManager;
 		}
 


### PR DESCRIPTION
1. Modified `SuppressErrorOccurredDialog` to be initiated inside `Script` with the correct value, because assigning it inside TestRunner doesn't work (the script itself creates a new instance of `Script`). Also added checks for it for all `ErrorDialog.Show` calls.
2. Fixed `A_SuspendExempt` to handle string input like `A_SuspendExempt := "1"`