### PR TITLE
Make thread configuration variables prototype-based

### DIFF
--- a/Keysharp.Core/Common/Keyboard/HotstringDefinition.cs
+++ b/Keysharp.Core/Common/Keyboard/HotstringDefinition.cs
@@ -358,7 +358,7 @@
 
 			// For the following, mSendMode isn't checked because the backup/restore is needed to varying extents
 			// by every mode.
-			var tv = script.Threads.GetThreadVariables();
+			var tv = script.Threads.GetThreadVariables().configData;
 			var oldDelay = tv.keyDelay;
 			var oldPressDuration = tv.keyDuration;
 			var oldDelayPlay = tv.keyDelayPlay;
@@ -428,7 +428,7 @@
 				{
 					ret = null;
 					var tv = script.Threads.GetThreadVariables();
-					tv.sendLevel = inputLevel;
+					tv.configData.sendLevel = inputLevel;
 					tv.hwndLastUsed = hwndCritFound;
 					tv.hotCriterion = hotCriterion;// v2: Let the Hotkey command use the criterion of this hotstring by default.
 					ret = funcObj.Call(o);

--- a/Keysharp.Core/Common/Platform/PlatformManagerBase.cs
+++ b/Keysharp.Core/Common/Platform/PlatformManagerBase.cs
@@ -12,7 +12,7 @@
 		internal void CoordToScreen(ref int aX, ref int aY, CoordMode modeType)
 		{
 			var script = Script.TheScript;
-			var coordMode = script.Coords.GetCoordMode(modeType);
+			var coordMode = ThreadAccessors.GetCoordMode(modeType);
 
 			if (coordMode == CoordModeType.Screen)
 				return;

--- a/Keysharp.Core/Common/Threading/ThreadVariables.cs
+++ b/Keysharp.Core/Common/Threading/ThreadVariables.cs
@@ -2,51 +2,97 @@
 
 namespace Keysharp.Core.Common.Threading
 {
-	public class ThreadVariables
+	public class ThreadConfigData
 	{
-		//internal Task<object> task = null;
-		internal bool task = false;
-		internal bool allowThreadToBeInterrupted = true;
+		public ThreadConfigData() { }
+
 		internal long controlDelay = 20L;
-		internal Timer currentTimer;
-		internal string defaultGui;
+		internal CoordModeType coordModeCaret = CoordModeType.Client;
+		internal CoordModeType coordModeMenu = CoordModeType.Client;
+		internal CoordModeType coordModeMouse = CoordModeType.Client;
+		internal CoordModeType coordModePixel = CoordModeType.Client;
+		internal CoordModeType coordModeToolTip = CoordModeType.Client;
 		internal long defaultMouseSpeed = 2L;
-		internal static readonly long DefaultPeekFrequency = 5L;
-		internal static readonly long DefaultUninterruptiblePeekFrequency = 16L;
 		internal bool detectHiddenText = true;
 		internal bool detectHiddenWindows;
-		internal Form dialogOwner;
-		internal object eventInfo;
 		internal Encoding fileEncoding = Encoding.Default;
-		internal IFuncObj hotCriterion;
-		internal long hwndLastUsed = 0;
-		internal bool isCritical = false;
 		internal long keyDelay = 10L;
 		internal long keyDelayPlay = -1L;
 		internal long keyDuration = -1L;
 		internal long keyDurationPlay = -1L;
-		internal long lastFoundForm;
 		internal long mouseDelay = 10L;
 		internal long mouseDelayPlay = -1L;
 		internal long peekFrequency = 5L;
-		internal long priority;
 #if WINDOWS
 		internal long regView = 64L;
 #endif
 		internal uint sendLevel;
 		internal SendModes sendMode = SendModes.Input;
 		internal bool storeCapsLockMode = true;
-		internal int threadId;
-		internal DateTime threadStartTime = DateTime.MinValue;
 		internal long titleMatchMode = 2L;
 		internal bool titleMatchModeSpeed = true;
-		internal int UninterruptibleDuration = 17;
 		internal long winDelay = 100L;
-		private CoordModes coords;
+
+		public ThreadConfigData Clone() => (ThreadConfigData)MemberwiseClone();
+
+		internal void CopyFromPrototypeConfigData()
+		{
+			var protoConfigData = Script.TheScript.AccessorData.threadConfigDataPrototype;
+			controlDelay = protoConfigData.controlDelay;
+			coordModeCaret = protoConfigData.coordModeCaret;
+			coordModeMenu = protoConfigData.coordModeMenu;
+			coordModeMouse = protoConfigData.coordModeMouse;
+			coordModePixel = protoConfigData.coordModePixel;
+			coordModeToolTip = protoConfigData.coordModeToolTip;
+			defaultMouseSpeed = protoConfigData.defaultMouseSpeed;
+			detectHiddenText = protoConfigData.detectHiddenText;
+			detectHiddenWindows = protoConfigData.detectHiddenWindows;
+			fileEncoding = protoConfigData.fileEncoding;
+			keyDelay = protoConfigData.keyDelay;
+			keyDelayPlay = protoConfigData.keyDelayPlay;
+			keyDuration = protoConfigData.keyDuration;
+			keyDurationPlay = protoConfigData.keyDurationPlay;
+			mouseDelay = protoConfigData.mouseDelay;
+			mouseDelayPlay = protoConfigData.mouseDelayPlay;
+			peekFrequency = protoConfigData.peekFrequency;
+#if WINDOWS
+			regView = protoConfigData.regView;
+#endif
+			sendLevel = protoConfigData.sendLevel;
+			sendMode = protoConfigData.sendMode;
+			storeCapsLockMode = protoConfigData.storeCapsLockMode;
+			titleMatchMode = protoConfigData.titleMatchMode;
+			titleMatchModeSpeed = protoConfigData.titleMatchModeSpeed;
+			winDelay = protoConfigData.winDelay;
+		}
+	}
+	public class ThreadVariables
+	{
+		internal static readonly long DefaultPeekFrequency = 5L;
+		internal static readonly long DefaultUninterruptiblePeekFrequency = 16L;
+
+		// These describe the runtime state of the pseudo-thread
+		//internal Task<object> task = null;
+		internal bool task = false;
+		internal bool isCritical = false;
+		internal bool allowThreadToBeInterrupted = true;
+		internal int UninterruptibleDuration = 17;
+		internal DateTime threadStartTime = DateTime.MinValue;
+		internal Timer currentTimer;
+		internal string defaultGui;
+		internal Form dialogOwner;
+		internal object eventInfo;
+		internal IFuncObj hotCriterion;
+		internal long hwndLastUsed = 0;
+		internal long lastFoundForm;
 		private Random randomGenerator;
 		private StringBuilder regsb = null;
+		internal long priority;
+		internal int threadId;
 
-		internal CoordModes Coords => coords != null ? coords : coords = new CoordModes();
+		// These describe the configuration defaults of the pseudo-thread,
+		// inherited from (and set by) the auto-execute section thread
+		internal ThreadConfigData configData = new ();
 
 		internal Random RandomGenerator
 		{
@@ -84,39 +130,17 @@ namespace Keysharp.Core.Common.Threading
 			allowThreadToBeInterrupted = true;
 			UninterruptibleDuration = 17;
 			threadStartTime = DateTime.MinValue;
-			controlDelay = 20L;
-			coords = null;
 			currentTimer = null;
 			defaultGui = null;
-			defaultMouseSpeed = 2L;
-			detectHiddenText = true;
-			detectHiddenWindows = false;
 			dialogOwner = null;
 			eventInfo = null;
-			fileEncoding = Encoding.Default;
 			hotCriterion = null;
 			hwndLastUsed = 0;
-			keyDelay = 10L;
-			keyDelayPlay = -1L;
-			keyDuration = -1L;
-			keyDurationPlay = -1L;
 			lastFoundForm = 0L;
-			mouseDelay = 10L;
-			mouseDelayPlay = -1L;
-			peekFrequency = 5L;
-			priority = 0L;
 			randomGenerator = null;
 			_ = (regsb?.Clear());
-#if WINDOWS
-			regView = 64L;
-#endif
-			sendLevel = 0;
-			sendMode = SendModes.Input;
-			storeCapsLockMode = true;
+			priority = 0L;
 			threadId = 0;
-			titleMatchMode = 2L;
-			titleMatchModeSpeed = true;
-			winDelay = 100L;
 		}
 
 		public void Init()
@@ -126,39 +150,21 @@ namespace Keysharp.Core.Common.Threading
 			allowThreadToBeInterrupted = true;
 			UninterruptibleDuration = Script.TheScript.uninterruptibleTime;
 			threadStartTime = DateTime.MinValue;
-			controlDelay = ControlDelayDefault;
-			coords = null;
 			currentTimer = null;
 			defaultGui = null;
-			defaultMouseSpeed = DefaultMouseSpeedDefault;
-			detectHiddenText = DetectHiddenTextDefault;
-			detectHiddenWindows = DetectHiddenWindowsDefault;
 			dialogOwner = null;
 			eventInfo = null;
-			fileEncoding = FileEncodingDefault;
 			hotCriterion = null;
 			hwndLastUsed = 0;
-			keyDelay = KeyDelayDefault;
-			keyDelayPlay = KeyDelayPlayDefault;
-			keyDuration = KeyDurationDefault;
-			keyDurationPlay = KeyDurationPlayDefault;
 			lastFoundForm = 0;
-			mouseDelay = MouseDelayDefault;
-			mouseDelayPlay = MouseDelayPlayDefault;
-			peekFrequency = PeekFrequencyDefault;
-			priority = A_Priority.Al();
 			randomGenerator = null;
 			_ = (regsb?.Clear());
-#if WINDOWS
-			regView = RegViewDefault;
-#endif
-			sendLevel = SendLevelDefault;
-			sendMode = SendModeDefault;
-			storeCapsLockMode = StoreCapsLockModeDefault;
+			priority = (long)A_Priority;
 			threadId = 0;
-			titleMatchMode = TitleMatchModeDefault;
-			titleMatchModeSpeed = TitleMatchModeSpeedDefault;
-			winDelay = WinDelayDefault;
+
+			// Instead of cloning the instance, copy the data because
+			// allocating the memory for new instances is expensive
+			configData.CopyFromPrototypeConfigData();
 		}
 	}
 }

--- a/Keysharp.Core/Common/Threading/Threads.cs
+++ b/Keysharp.Core/Common/Threading/Threads.cs
@@ -162,7 +162,7 @@
 				tv.allowThreadToBeInterrupted = true; // Avoids issues with 49.7 day limit of 32-bit TickCount, and also helps performance future callers of this function (they can skip most of the checking above).
 
 				if (!tv.isCritical)
-					tv.peekFrequency = ThreadVariables.DefaultPeekFrequency;
+					tv.configData.peekFrequency = ThreadVariables.DefaultPeekFrequency;
 			}
 
 			return tv.allowThreadToBeInterrupted;

--- a/Keysharp.Core/Common/Window/WindowItemBase.cs
+++ b/Keysharp.Core/Common/Window/WindowItemBase.cs
@@ -370,7 +370,7 @@
 			if (string.IsNullOrEmpty(a))
 				return false;
 
-			switch (Script.TheScript.Threads.GetThreadVariables().titleMatchMode.ParseLong(false))
+			switch (ThreadAccessors.A_TitleMatchMode)
 			{
 				case 1:
 					return a.StartsWith(b, comp);

--- a/Keysharp.Core/Core/Accessors.cs
+++ b/Keysharp.Core/Core/Accessors.cs
@@ -7,35 +7,12 @@
 		internal long maxHotkeysPerInterval = 2000L;
 		internal readonly string initialWorkingDir = Environment.CurrentDirectory;
 		internal bool allowMainWindow = true;
-		internal long controlDelay = 20L;
-		internal CoordModeType coordModeCaretDefault = CoordModeType.Client;
-		internal CoordModeType coordModeMenuDefault = CoordModeType.Client;
-		internal CoordModeType coordModeMouseDefault = CoordModeType.Client;
-		internal CoordModeType coordModePixelDefault = CoordModeType.Client;
-		internal CoordModeType coordModeToolTipDefault = CoordModeType.Client;
-		internal long defaultMouseSpeed = 2L;
-		internal bool detectHiddenText = true;
-		internal bool detectHiddenWindows = false;
-		internal Encoding fileEncoding = Encoding.Default;
 		internal bool? iconFrozen;
 		internal bool iconHidden;
 		internal uint inputLevel;
-		internal long keyDelay = 10L;
-		internal long keyDelayPlay = -1L;
-		internal long keyDuration = -1L;
-		internal long keyDurationPlay = -1L;
 		internal string menuMaskKey = "";
-		internal long mouseDelay = 10L;
-		internal long mouseDelayPlay = -1L;
-		internal long peekFrequency = 5L;
 		internal Icon prevTrayIcon;
-		internal long regView = 64L;
-		internal uint sendLevel = 0;
-		internal SendModes sendMode = SendModes.Input;
-		internal bool storeCapsLockMode = true;
-		internal long titleMatchMode = 2L;
-		internal bool titleMatchModeSpeed = true;
-		internal long winDelay = 100L;
+		internal ThreadConfigData threadConfigDataPrototype = new (); // Used (and set by) the auto-execute section
 	}
 
 	/// <summary>
@@ -332,16 +309,7 @@
 		{
 			get => ThreadAccessors.A_ControlDelay;
 
-			set
-			{
-				var val = value.Al();
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.controlDelay = val;
-
-				ThreadAccessors.A_ControlDelay = val;
-			}
+			set => ThreadAccessors.A_ControlDelay = value.Al();
 		}
 
 		/// <summary>
@@ -350,12 +318,11 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
 		public static object A_CoordModeCaret
 		{
-			get => CoordModeTypeToString(Script.TheScript.Coords.Caret);
+			get => CoordModeTypeToString(ThreadAccessors.A_CoordModeCaret);
 
 			set
 			{
 				var val = CoordModeType.Client;
-				var script = Script.TheScript;
 
 				if (value is CoordModeType cmt)
 					val = cmt;
@@ -367,10 +334,7 @@
 					return;
 				}
 
-				if (!script.IsReadyToExecute)
-					script.AccessorData.coordModeCaretDefault = val;
-
-				script.Coords.Caret = val;
+				ThreadAccessors.A_CoordModeCaret = val;
 			}
 		}
 
@@ -380,12 +344,11 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
 		public static object A_CoordModeMenu
 		{
-			get => CoordModeTypeToString(Script.TheScript.Coords.Menu);
+			get => CoordModeTypeToString(ThreadAccessors.A_CoordModeMenu);
 
 			set
 			{
 				var val = CoordModeType.Client;
-				var script = Script.TheScript;
 
 				if (value is CoordModeType cmt)
 					val = cmt;
@@ -397,10 +360,7 @@
 					return;
 				}
 
-				if (!script.IsReadyToExecute)
-					script.AccessorData.coordModeMenuDefault = val;
-
-				script.Coords.Menu = val;
+				ThreadAccessors.A_CoordModeMenu = val;
 			}
 		}
 
@@ -410,12 +370,11 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
 		public static object A_CoordModeMouse
 		{
-			get => CoordModeTypeToString(Script.TheScript.Coords.Mouse);
+			get => CoordModeTypeToString(ThreadAccessors.A_CoordModeMouse);
 
 			set
 			{
 				var val = CoordModeType.Client;
-				var script = Script.TheScript;
 
 				if (value is CoordModeType cmt)
 					val = cmt;
@@ -427,10 +386,7 @@
 					return;
 				}
 
-				if (!script.IsReadyToExecute)
-					script.AccessorData.coordModeMouseDefault = val;
-
-				script.Coords.Mouse = val;
+				ThreadAccessors.A_CoordModeMouse = val;
 			}
 		}
 
@@ -440,12 +396,11 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
 		public static object A_CoordModePixel
 		{
-			get => CoordModeTypeToString(Script.TheScript.Coords.Pixel);
+			get => CoordModeTypeToString(ThreadAccessors.A_CoordModePixel);
 
 			set
 			{
 				var val = CoordModeType.Client;
-				var script = Script.TheScript;
 
 				if (value is CoordModeType cmt)
 					val = cmt;
@@ -457,10 +412,7 @@
 					return;
 				}
 
-				if (!script.IsReadyToExecute)
-					script.AccessorData.coordModePixelDefault = val;
-
-				script.Coords.Pixel = val;
+				ThreadAccessors.A_CoordModePixel = val;
 			}
 		}
 
@@ -470,12 +422,11 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
 		public static object A_CoordModeToolTip
 		{
-			get => CoordModeTypeToString(Script.TheScript.Coords.Tooltip);
+			get => CoordModeTypeToString(ThreadAccessors.A_CoordModeToolTip);
 
 			set
 			{
 				var val = CoordModeType.Client;
-				var script = Script.TheScript;
 
 				if (value is CoordModeType cmt)
 					val = cmt;
@@ -487,10 +438,7 @@
 					return;
 				}
 
-				if (!script.IsReadyToExecute)
-					script.AccessorData.coordModeToolTipDefault = val;
-
-				script.Coords.Tooltip = val;
+				ThreadAccessors.A_CoordModeToolTip = val;
 			}
 		}
 
@@ -530,17 +478,7 @@
 		public static object A_DefaultMouseSpeed
 		{
 			get => ThreadAccessors.A_DefaultMouseSpeed;
-
-			set
-			{
-				var val = value.Al();
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.defaultMouseSpeed = val;
-
-				ThreadAccessors.A_DefaultMouseSpeed = val;
-			}
+			set => ThreadAccessors.A_DefaultMouseSpeed = value.Al();
 		}
 
 		/// <summary>
@@ -567,11 +505,6 @@
 				if (val != null)
 				{
 					var b = val.Value.Ab();
-					var script = Script.TheScript;
-
-					if (!script.IsReadyToExecute)
-						script.AccessorData.detectHiddenText = b;
-
 					ThreadAccessors.A_DetectHiddenText = b;
 				}
 			}
@@ -591,11 +524,6 @@
 				if (val != null)
 				{
 					var b = val.Value.Ab();
-					var script = Script.TheScript;
-
-					if (!script.IsReadyToExecute)
-						script.AccessorData.detectHiddenWindows = b;
-
 					ThreadAccessors.A_DetectHiddenWindows = b;
 				}
 			}
@@ -634,11 +562,6 @@
 			set
 			{
 				var val = Files.GetEncoding(value.ToString());
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.fileEncoding = val;
-
 				ThreadAccessors.A_FileEncoding = val;
 			}
 		}
@@ -832,7 +755,7 @@
 			get
 			{
 				var tv = Script.TheScript.Threads.GetThreadVariables();
-				return tv.isCritical ? tv.peekFrequency : 0L;
+				return tv.isCritical ? tv.configData.peekFrequency : 0L;
 			}
 		}
 
@@ -863,17 +786,7 @@
 		public static object A_KeyDelay
 		{
 			get => ThreadAccessors.A_KeyDelay;
-
-			set
-			{
-				var val = value.Al();
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.keyDelay = val;
-
-				ThreadAccessors.A_KeyDelay = val;
-			}
+			set => ThreadAccessors.A_KeyDelay = value.Al();
 		}
 
 		/// <summary>
@@ -883,16 +796,7 @@
 		{
 			get => ThreadAccessors.A_KeyDelayPlay;
 
-			set
-			{
-				var val = value.Al();
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.keyDelayPlay = val;
-
-				ThreadAccessors.A_KeyDelayPlay = val;
-			}
+			set => ThreadAccessors.A_KeyDelayPlay = value.Al();
 		}
 
 		/// <summary>
@@ -901,17 +805,7 @@
 		public static object A_KeyDuration
 		{
 			get => ThreadAccessors.A_KeyDuration;
-
-			set
-			{
-				var val = value.Al();
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.keyDuration = val;
-
-				ThreadAccessors.A_KeyDuration = val;
-			}
+			set => ThreadAccessors.A_KeyDuration = value.Al();
 		}
 
 		/// <summary>
@@ -920,17 +814,7 @@
 		public static object A_KeyDurationPlay
 		{
 			get => ThreadAccessors.A_KeyDurationPlay;
-
-			set
-			{
-				var val = value.Al();
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.keyDurationPlay = val;
-
-				ThreadAccessors.A_KeyDurationPlay = val;
-			}
+			set => ThreadAccessors.A_KeyDurationPlay = value.Al();
 		}
 
 		/// <summary>
@@ -1416,16 +1300,7 @@
 		{
 			get => ThreadAccessors.A_MouseDelay;
 
-			set
-			{
-				var val = value.Al();
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.mouseDelay = val;
-
-				ThreadAccessors.A_MouseDelay = val;
-			}
+			set => ThreadAccessors.A_MouseDelay = value.Al();
 		}
 
 		/// <summary>
@@ -1434,17 +1309,7 @@
 		public static object A_MouseDelayPlay
 		{
 			get => ThreadAccessors.A_MouseDelayPlay;
-
-			set
-			{
-				var val = value.Al();
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.mouseDelayPlay = val;
-
-				ThreadAccessors.A_MouseDelayPlay = val;
-			}
+			set => ThreadAccessors.A_MouseDelayPlay = value.Al();
 		}
 
 		/// <summary>
@@ -1501,17 +1366,7 @@
 		public static object A_PeekFrequency
 		{
 			get => ThreadAccessors.A_PeekFrequency;
-
-			set
-			{
-				var val = value.Al();
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.peekFrequency = val;
-
-				ThreadAccessors.A_PeekFrequency = val;
-			}
+			set => ThreadAccessors.A_PeekFrequency = value.Al();
 		}
 
 		/// <summary>
@@ -1567,11 +1422,6 @@
 			set
 			{
 				var val = value is string s && s.Equals("default", StringComparison.CurrentCultureIgnoreCase) ? 64L : value.Al() == 32L ? 32L : 64L;
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.regView = val;
-
 				ThreadAccessors.A_RegView = val;
 			}
 		}
@@ -1649,20 +1499,10 @@
 		/// The send level to use when sending keys.<br/>
 		/// The range is 0-100.
 		/// </summary>
-		public static object A_SendLevel
+		public static long A_SendLevel
 		{
 			get => ThreadAccessors.A_SendLevel;
-
-			set
-			{
-				var val = (uint)Math.Clamp(value.Al(), 0L, 100L);
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.sendLevel = val;
-
-				ThreadAccessors.A_SendLevel = val;
-			}
+			set => ThreadAccessors.A_SendLevel = (uint)Math.Clamp(value.Al(), 0L, 100L);
 		}
 
 		/// <summary>
@@ -1677,11 +1517,6 @@
 			{
 				if (Enum.TryParse<SendModes>(value.As(), out var val))
 				{
-					var script = Script.TheScript;
-
-					if (!script.IsReadyToExecute)
-						script.AccessorData.sendMode = val;
-
 					ThreadAccessors.A_SendMode = val;
 				}
 			}
@@ -1725,11 +1560,6 @@
 
 				if (val != null)
 				{
-					var script = Script.TheScript;
-
-					if (!script.IsReadyToExecute)
-						script.AccessorData.storeCapsLockMode = val.Value;
-
 					ThreadAccessors.A_StoreCapsLockMode = val.Value;
 				}
 			}
@@ -1837,7 +1667,11 @@
 		/// </summary>
 		public static object A_TitleMatchMode
 		{
-			get => ThreadAccessors.A_TitleMatchMode;
+			get
+			{
+				var l = ThreadAccessors.A_TitleMatchMode;
+				return l == 4L ? Keyword_RegEx : l;
+			}
 
 			set
 			{
@@ -1852,10 +1686,7 @@
 					_ => 2L
 				};
 
-				if (!script.IsReadyToExecute)
-					script.AccessorData.titleMatchMode = val;
-
-				script.Threads.GetThreadVariables().titleMatchMode = val;
+				ThreadAccessors.A_TitleMatchMode = val;
 			}
 		}
 
@@ -1864,7 +1695,7 @@
 		/// </summary>
 		public static object A_TitleMatchModeSpeed
 		{
-			get => ThreadAccessors.A_TitleMatchModeSpeed.Ab() ? Keyword_Fast : Keyword_Slow;
+			get => ThreadAccessors.A_TitleMatchModeSpeed ? Keyword_Fast : Keyword_Slow;
 
 			set
 			{
@@ -1877,9 +1708,6 @@
 
 					case Keyword_Slow: val = false; break;
 				}
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.titleMatchModeSpeed = val;
 
 				ThreadAccessors.A_TitleMatchModeSpeed = val;
 			}
@@ -1906,17 +1734,7 @@
 		public static object A_WinDelay
 		{
 			get => ThreadAccessors.A_WinDelay;
-
-			set
-			{
-				var val = value.Al();
-				var script = Script.TheScript;
-
-				if (!script.IsReadyToExecute)
-					script.AccessorData.winDelay = val;
-
-				ThreadAccessors.A_WinDelay = val;
-			}
+			set => ThreadAccessors.A_WinDelay = value.Al();
 		}
 
 #if WINDOWS
@@ -2006,32 +1824,32 @@
 		/// </summary>
 		internal static double A_ScaledScreenDPI => A_ScreenDPI / 96.0;
 
-		internal static long ControlDelayDefault => Script.TheScript.AccessorData.controlDelay;
-		internal static CoordModeType CoordModeCaretDefault => Script.TheScript.AccessorData.coordModeCaretDefault;
-		internal static CoordModeType CoordModeMenuDefault => Script.TheScript.AccessorData.coordModeMenuDefault;
-		internal static CoordModeType CoordModeMouseDefault => Script.TheScript.AccessorData.coordModeMouseDefault;
-		internal static CoordModeType CoordModePixelDefault => Script.TheScript.AccessorData.coordModePixelDefault;
-		internal static CoordModeType CoordModeToolTipDefault => Script.TheScript.AccessorData.coordModeToolTipDefault;
-		internal static long DefaultMouseSpeedDefault => Script.TheScript.AccessorData.defaultMouseSpeed;
-		internal static bool DetectHiddenTextDefault => Script.TheScript.AccessorData.detectHiddenText;
-		internal static bool DetectHiddenWindowsDefault => Script.TheScript.AccessorData.detectHiddenWindows;
-		internal static Encoding FileEncodingDefault => Script.TheScript.AccessorData.fileEncoding;
-		internal static long KeyDelayDefault => Script.TheScript.AccessorData.keyDelay;
-		internal static long KeyDelayPlayDefault => Script.TheScript.AccessorData.keyDelayPlay;
-		internal static long KeyDurationDefault => Script.TheScript.AccessorData.keyDuration;
-		internal static long KeyDurationPlayDefault => Script.TheScript.AccessorData.keyDurationPlay;
-		internal static long MouseDelayDefault => Script.TheScript.AccessorData.mouseDelay;
-		internal static long MouseDelayPlayDefault => Script.TheScript.AccessorData.mouseDelayPlay;
-		internal static long PeekFrequencyDefault => Script.TheScript.AccessorData.peekFrequency;
+		internal static long ControlDelayDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.controlDelay;
+		internal static CoordModeType CoordModeCaretDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.coordModeCaret;
+		internal static CoordModeType CoordModeMenuDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.coordModeMenu;
+		internal static CoordModeType CoordModeMouseDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.coordModeMouse;
+		internal static CoordModeType CoordModePixelDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.coordModePixel;
+		internal static CoordModeType CoordModeToolTipDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.coordModeToolTip;
+		internal static long DefaultMouseSpeedDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.defaultMouseSpeed;
+		internal static bool DetectHiddenTextDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.detectHiddenText;
+		internal static bool DetectHiddenWindowsDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.detectHiddenWindows;
+		internal static Encoding FileEncodingDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.fileEncoding;
+		internal static long KeyDelayDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.keyDelay;
+		internal static long KeyDelayPlayDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.keyDelayPlay;
+		internal static long KeyDurationDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.keyDuration;
+		internal static long KeyDurationPlayDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.keyDurationPlay;
+		internal static long MouseDelayDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.mouseDelay;
+		internal static long MouseDelayPlayDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.mouseDelayPlay;
+		internal static long PeekFrequencyDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.peekFrequency;
 #if WINDOWS
-		internal static long RegViewDefault => Script.TheScript.AccessorData.regView;
+		internal static long RegViewDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.regView;
 #endif
-		internal static uint SendLevelDefault => Script.TheScript.AccessorData.sendLevel;
-		internal static SendModes SendModeDefault => Script.TheScript.AccessorData.sendMode;
-		internal static bool StoreCapsLockModeDefault => Script.TheScript.AccessorData.storeCapsLockMode;
-		internal static long TitleMatchModeDefault => Script.TheScript.AccessorData.titleMatchMode;
-		internal static bool TitleMatchModeSpeedDefault => Script.TheScript.AccessorData.titleMatchModeSpeed;
-		internal static long WinDelayDefault => Script.TheScript.AccessorData.winDelay;
+		internal static long SendLevelDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.sendLevel;
+		internal static SendModes SendModeDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.sendMode;
+		internal static bool StoreCapsLockModeDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.storeCapsLockMode;
+		internal static long TitleMatchModeDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.titleMatchMode;
+		internal static bool TitleMatchModeSpeedDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.titleMatchModeSpeed;
+		internal static long WinDelayDefault => Script.TheScript.AccessorData.threadConfigDataPrototype.winDelay;
 
 		//if (A_IsCompiled != 0)//  return Path.GetFileName(GetAssembly().Location);//else if (scriptName == "*")//  return "*";//else//  return Path.GetFileName(scriptName);
 
@@ -2331,22 +2149,121 @@
 	internal static class ThreadAccessors
 	{
 		/// <summary>
+		/// Retrieves the coordinate mode for the specified operation.
+		/// </summary>
+		/// <param name="mode">The operation to retrieve the coordinate mode for.</param>
+		/// <returns>The coordinate mode for the specified operation.</returns>
+		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if an invalid coordinate operation is specified.</exception>
+		internal static CoordModeType GetCoordMode(CoordMode mode)
+		{
+			return mode switch
+			{
+				CoordMode.Caret => A_CoordModeCaret,
+				CoordMode.Menu => A_CoordModeMenu,
+				CoordMode.Mouse => A_CoordModeMouse,
+				CoordMode.Pixel => A_CoordModePixel,
+				CoordMode.Tooltip => A_CoordModeToolTip,
+				_ => (CoordModeType)Errors.ValueErrorOccurred($"Invalid coordinate mode type: {mode}", null, CoordModeType.Client)
+			};
+		}
+
+		/// <summary>
+		/// The coordinate mode for positioning the caret.
+		/// </summary>
+		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
+		public static CoordModeType A_CoordModeCaret
+		{
+			get => Script.TheScript.Threads.GetThreadVariables().configData.coordModeCaret;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.coordModeCaret = value;
+		}
+
+		/// <summary>
+		/// The coordinate mode for positioning menus.
+		/// </summary>
+		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
+		public static CoordModeType A_CoordModeMenu
+		{
+			get => Script.TheScript.Threads.GetThreadVariables().configData.coordModeMenu;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.coordModeMenu = value;
+		}
+
+		/// <summary>
+		/// The coordinate mode for positioning the mouse.
+		/// </summary>
+		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
+		public static CoordModeType A_CoordModeMouse
+		{
+			get => Script.TheScript.Threads.GetThreadVariables().configData.coordModeMouse;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.coordModeMouse = value;
+		}
+
+		/// <summary>
+		/// The coordinate mode for positioning pixels.
+		/// </summary>
+		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
+		public static CoordModeType A_CoordModePixel
+		{
+			get => Script.TheScript.Threads.GetThreadVariables().configData.coordModePixel;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.coordModePixel = value;
+		}
+
+		/// <summary>
+		/// The coordinate mode for positioning tooltips.
+		/// </summary>
+		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
+		public static CoordModeType A_CoordModeToolTip
+		{
+			get => Script.TheScript.Threads.GetThreadVariables().configData.coordModeToolTip;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.coordModeToolTip = value;
+		}
+
+		/// <summary>
+		/// The type of mouse cursor currently being displayed. It will be one of the following words:<br/>
+		/// AppStarting, Arrow, Cross, Help, IBeam, Icon, No, Size, SizeAll, SizeNESW, SizeNS, SizeNWSE, SizeWE, UpArrow, Wait, Unknown.<br/>
+		/// The acronyms used with the size-type cursors are compass directions, e.g. NESW = NorthEast+SouthWest.<br/>
+		/// The hand-shaped cursors (pointing and grabbing) are classified as Unknown.
+		/// </summary>
+		public static string A_Cursor =>
+		Cursor.Current is Cursor cur ?
+#if LINUX
+		cur.ToString().Trim(BothBrackets).Split(':', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)[1]
+#elif WINDOWS
+		cur.ToString().Trim(BothBrackets).Split(' ', StringSplitOptions.RemoveEmptyEntries)[1].Replace("Cursor", "")
+#endif
+		: "Default---";
+
+		/// <summary>
+		/// See <see cref="A_MDay"/>.
+		/// </summary>
+		public static string A_DD => A_MDay;
+
+		/// <summary>
+		/// Current day of the week's 3-letter abbreviation in the current user's language, e.g. Sun.
+		/// </summary>
+		public static string A_DDD => DateTime.Now.ToString("ddd");
+
+		/// <summary>
+		/// Current day of the week's full name in the current user's language, e.g. Sunday.
+		/// </summary>
+		public static string A_DDDD => DateTime.Now.ToString("dddd");
+
+		/// <summary>
+		/// Sets the mouse speed that will be used if unspecified in <see cref="Click"/>.
+		/// </summary>
+		public static long A_DefaultMouseSpeed
+		{
+			get => Script.TheScript.Threads.GetThreadVariables().configData.defaultMouseSpeed;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.defaultMouseSpeed = value;
+		}
+
+		/// <summary>
 		/// The delay for control-modifying functions, in milliseconds. For details, see <see cref="SetControlDelay"/>.
 		/// Unused, because no control delays are needed.
 		/// </summary>
 		internal static long A_ControlDelay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().controlDelay;
-			set => Script.TheScript.Threads.GetThreadVariables().controlDelay = value;
-		}
-
-		/// <summary>
-		/// The default mouse speed, an integer from 0 (fastest) to 100 (slowest).
-		/// </summary>
-		internal static long A_DefaultMouseSpeed
-		{
-			get => Script.TheScript.Threads.GetThreadVariables().defaultMouseSpeed;
-			set => Script.TheScript.Threads.GetThreadVariables().defaultMouseSpeed = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.controlDelay;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.controlDelay = value;
 		}
 
 		/// <summary>
@@ -2354,8 +2271,8 @@
 		/// </summary>
 		internal static bool A_DetectHiddenText
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().detectHiddenText;
-			set => Script.TheScript.Threads.GetThreadVariables().detectHiddenText = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.detectHiddenText;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.detectHiddenText = value;
 		}
 
 		/// <summary>
@@ -2363,8 +2280,8 @@
 		/// </summary>
 		internal static bool A_DetectHiddenWindows
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().detectHiddenWindows;
-			set => Script.TheScript.Threads.GetThreadVariables().detectHiddenWindows = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.detectHiddenWindows;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.detectHiddenWindows = value;
 		}
 
 		/// <summary>
@@ -2401,22 +2318,22 @@
 			}
 			set
 			{
-				Script.TheScript.Threads.GetThreadVariables().fileEncoding = value is Encoding enc ? enc : Files.GetEncoding(value.ToString());
+				Script.TheScript.Threads.GetThreadVariables().configData.fileEncoding = value is Encoding enc ? enc : Files.GetEncoding(value.ToString());
 			}
 		}
 
 		/// <summary>
 		/// Wrapper to retrieve the file encoding as an <see cref="Encoding"/> object.
 		/// </summary>
-		internal static Encoding A_FileEncodingRaw => Script.TheScript.Threads.GetThreadVariables().fileEncoding;
+		internal static Encoding A_FileEncodingRaw => Script.TheScript.Threads.GetThreadVariables().configData.fileEncoding;
 
 		/// <summary>
 		/// The delay in milliseconds between SendEvent keystrokes.
 		/// </summary>
 		internal static long A_KeyDelay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().keyDelay;
-			set => Script.TheScript.Threads.GetThreadVariables().keyDelay = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.keyDelay;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.keyDelay = value;
 		}
 
 		/// <summary>
@@ -2424,8 +2341,8 @@
 		/// </summary>
 		internal static long A_KeyDelayPlay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().keyDelayPlay;
-			set => Script.TheScript.Threads.GetThreadVariables().keyDelayPlay = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.keyDelayPlay;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.keyDelayPlay = value;
 		}
 
 		/// <summary>
@@ -2433,8 +2350,8 @@
 		/// </summary>
 		internal static long A_KeyDuration
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().keyDuration;
-			set => Script.TheScript.Threads.GetThreadVariables().keyDuration = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.keyDuration;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.keyDuration = value;
 		}
 
 		/// <summary>
@@ -2442,8 +2359,8 @@
 		/// </summary>
 		internal static long A_KeyDurationPlay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().keyDurationPlay;
-			set => Script.TheScript.Threads.GetThreadVariables().keyDurationPlay = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.keyDurationPlay;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.keyDurationPlay = value;
 		}
 
 		/// <summary>
@@ -2451,8 +2368,8 @@
 		/// </summary>
 		internal static long A_MouseDelay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().mouseDelay;
-			set => Script.TheScript.Threads.GetThreadVariables().mouseDelay = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.mouseDelay;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.mouseDelay = value;
 		}
 
 		/// <summary>
@@ -2460,8 +2377,8 @@
 		/// </summary>
 		internal static long A_MouseDelayPlay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().mouseDelayPlay;
-			set => Script.TheScript.Threads.GetThreadVariables().mouseDelayPlay = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.mouseDelayPlay;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.mouseDelayPlay = value;
 		}
 
 		/// <summary>
@@ -2469,8 +2386,8 @@
 		/// Unused because Keysharp is compiled and not interpreted.
 		internal static long A_PeekFrequency
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().peekFrequency;
-			set => Script.TheScript.Threads.GetThreadVariables().peekFrequency = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.peekFrequency;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.peekFrequency = value;
 		}
 
 #if WINDOWS
@@ -2480,8 +2397,8 @@
 		/// </summary>
 		internal static long A_RegView
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().regView;
-			set => Script.TheScript.Threads.GetThreadVariables().regView = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.regView;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.regView = value;
 		}
 
 #endif
@@ -2492,8 +2409,8 @@
 		/// </summary>
 		internal static uint A_SendLevel
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().sendLevel;
-			set => Script.TheScript.Threads.GetThreadVariables().sendLevel = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.sendLevel;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.sendLevel = value;
 		}
 
 		/// <summary>
@@ -2502,8 +2419,8 @@
 		/// </summary>
 		internal static SendModes A_SendMode
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().sendMode;
-			set => Script.TheScript.Threads.GetThreadVariables().sendMode = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.sendMode;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.sendMode = value;
 		}
 
 		/// <summary>
@@ -2511,57 +2428,20 @@
 		/// </summary>
 		internal static bool A_StoreCapsLockMode
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().storeCapsLockMode;
-			set => Script.TheScript.Threads.GetThreadVariables().storeCapsLockMode = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.storeCapsLockMode;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.storeCapsLockMode = value;
 		}
 
-		internal static object A_TitleMatchMode
+		internal static long A_TitleMatchMode
 		{
-			get
-			{
-				var l = Script.TheScript.Threads.GetThreadVariables().titleMatchMode;
-				return l == 4L ? Keyword_RegEx : l;
-			}
-			set
-			{
-				var vars = Script.TheScript.Threads.GetThreadVariables();
-
-				switch (value.ToString().ToLower())
-				{
-					case "1": vars.titleMatchMode = 1L; break;
-
-					case "2": vars.titleMatchMode = 2L; break;
-
-					case "3": vars.titleMatchMode = 3L; break;
-
-					case Keyword_RegEx:
-						vars.titleMatchMode = 4L; break;
-				}
-			}
+			get => Script.TheScript.Threads.GetThreadVariables().configData.titleMatchMode;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.titleMatchMode = value;
 		}
 
-		internal static object A_TitleMatchModeSpeed
+		internal static bool A_TitleMatchModeSpeed
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().titleMatchModeSpeed;
-
-			set
-			{
-				var vars = Script.TheScript.Threads.GetThreadVariables();
-
-				if (value is bool b)
-				{
-					vars.titleMatchModeSpeed = b;
-				}
-				else
-				{
-					switch (value.ToString().ToLowerInvariant())
-					{
-						case Keyword_Fast: vars.titleMatchModeSpeed = true; break;
-
-						case Keyword_Slow: vars.titleMatchModeSpeed = false; break;
-					}
-				}
-			}
+			get => Script.TheScript.Threads.GetThreadVariables().configData.titleMatchModeSpeed;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.titleMatchModeSpeed = value;
 		}
 
 		/// <summary>
@@ -2569,8 +2449,8 @@
 		/// </summary>
 		internal static long A_WinDelay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().winDelay;
-			set => Script.TheScript.Threads.GetThreadVariables().winDelay = value;
+			get => Script.TheScript.Threads.GetThreadVariables().configData.winDelay;
+			set => Script.TheScript.Threads.GetThreadVariables().configData.winDelay = value;
 		}
 	}
 }

--- a/Keysharp.Core/Core/Debug.cs
+++ b/Keysharp.Core/Core/Debug.cs
@@ -12,7 +12,7 @@
 
 			var script = Script.TheScript;
 			var title = script.mainWindow != null ? script.mainWindow.Text : "";
-			var tv = script.Threads.GetThreadVariables();
+			var tv = script.Threads.GetThreadVariables().configData;
 			var mm = tv.titleMatchMode;
 			tv.titleMatchMode = 2L;//Match anywhere.
 			var hwnd = WindowX.WinExist(A_ScriptName, "", title, "");

--- a/Keysharp.Core/Core/Flow.cs
+++ b/Keysharp.Core/Core/Flow.cs
@@ -47,7 +47,7 @@ namespace Keysharp.Core
 				}
 			}
 
-			var ret = tv.isCritical ? tv.peekFrequency : 0L;
+			var ret = tv.isCritical ? tv.configData.peekFrequency : 0L;
 			// v1.0.46: When the current thread is critical, have the script check messages less often to
 			// reduce situations where an OnMessage or GUI message must be discarded due to "thread already
 			// running".  Using 16 rather than the default of 5 solves reliability problems in a custom-menu-draw
@@ -69,7 +69,7 @@ namespace Keysharp.Core
 
 			if (tv.isCritical) // Critical has been turned on. (For simplicity even if it was already on, the following is done.)
 			{
-				tv.peekFrequency = freq;
+				tv.configData.peekFrequency = freq;
 				tv.allowThreadToBeInterrupted = false;
 				// Ensure uninterruptibility never times out.  IsInterruptible() relies on this to avoid the
 				// need to check g->ThreadIsCritical, which in turn allows global_maximize_interruptibility()
@@ -84,7 +84,7 @@ namespace Keysharp.Core
 			{
 				// Since Critical is being turned off, allow thread to be immediately interrupted regardless of
 				// any "Thread Interrupt" settings.
-				tv.peekFrequency = 5;
+				tv.configData.peekFrequency = 5;
 				tv.allowThreadToBeInterrupted = true;
 			}
 

--- a/Keysharp.Core/Core/Gui/Menu.cs
+++ b/Keysharp.Core/Core/Gui/Menu.cs
@@ -372,7 +372,7 @@
 			var _y = y.Ai(Cursor.Position.Y);
 			var pt = new Point(_x, _y);
 
-			if (Script.TheScript.Coords.Menu == CoordModeType.Screen)
+			if (ThreadAccessors.A_CoordModeMenu == CoordModeType.Screen)
 				if (Form.ActiveForm is Form form)
 					pt = form.PointToClient(pt);
 

--- a/Keysharp.Core/Core/Gui/ToolTips.cs
+++ b/Keysharp.Core/Core/Gui/ToolTips.cs
@@ -109,7 +109,7 @@
 #endif
 			}, false);
 			// CheckedBeginInvoke might run in a different thread with a different CoordMode
-			var coordModeToolTip = script.Coords.Tooltip;
+			var coordModeToolTip = ThreadAccessors.A_CoordModeToolTip;
 			tooltipInvokerForm.CheckedBeginInvoke(() =>
 			{
 #if LINUX

--- a/Keysharp.Core/Core/Gui/WindowX.cs
+++ b/Keysharp.Core/Core/Gui/WindowX.cs
@@ -1047,7 +1047,7 @@ namespace Keysharp.Core
 									 object excludeTitle = null,
 									 object excludeText = null)
 		{
-			var tv = Script.TheScript.Threads.GetThreadVariables();
+			var tv = Script.TheScript.Threads.GetThreadVariables().configData;
 			var prev = tv.detectHiddenWindows;
 			tv.detectHiddenWindows = true;
 			SearchWindows(winTitle, winText, excludeTitle, excludeText).ForEach(win => win.Show());

--- a/Keysharp.Core/Core/Keyboard.cs
+++ b/Keysharp.Core/Core/Keyboard.cs
@@ -695,7 +695,7 @@ break_twice:;
 		public static object SendLevel(object level)
 		{
 			var old = A_SendLevel;
-			A_SendLevel = level;
+			A_SendLevel = level.Al();
 			return old;
 		}
 

--- a/Keysharp.Core/Core/Mouse.cs
+++ b/Keysharp.Core/Core/Mouse.cs
@@ -343,13 +343,13 @@ namespace Keysharp.Core
 		{
 			var script = Script.TheScript;
 
-			if (script.Coords.Mouse == CoordModeType.Window)
+			if (ThreadAccessors.A_CoordModeMouse == CoordModeType.Window)
 			{
 				var rect = script.WindowProvider.Manager.ActiveWindow.Location;
 				x += rect.Left;
 				y += rect.Top;
 			}
-			else if (script.Coords.Mouse == CoordModeType.Client)
+			else if (ThreadAccessors.A_CoordModeMouse == CoordModeType.Client)
 			{
 				var pt = script.WindowProvider.Manager.ActiveWindow.ClientToScreen();
 				x += pt.X;
@@ -369,7 +369,7 @@ namespace Keysharp.Core
 		{
 			var script = Script.TheScript;
 
-			if (script.Coords.Mouse == CoordModeType.Window)
+			if (ThreadAccessors.A_CoordModeMouse == CoordModeType.Window)
 			{
 				var rect = script.WindowProvider.Manager.ActiveWindow.Location;
 				x1 += rect.Left;
@@ -377,7 +377,7 @@ namespace Keysharp.Core
 				x2 += rect.Left;
 				y2 += rect.Top;
 			}
-			else if (script.Coords.Mouse == CoordModeType.Client)
+			else if (ThreadAccessors.A_CoordModeMouse == CoordModeType.Client)
 			{
 				var pt = script.WindowProvider.Manager.ActiveWindow.ClientToScreen();
 				x1 += pt.X;
@@ -488,70 +488,6 @@ namespace Keysharp.Core
 											  , eventType
 											  , speed
 											  , relative.Length > 0 && char.ToUpper(relative[0]) == 'R');
-		}
-	}
-
-	/// <summary>
-	/// Class to hold the coordinate modes for various operations.
-	/// The properties will start with the default values set in the auto exec section.
-	/// A new instance of this class will be lazily instantiated in each thread.
-	/// </summary>
-	internal class CoordModes
-	{
-		/// <summary>
-		/// Constructor that starts each field off with the global default set by the auto exec section.
-		/// </summary>
-		internal CoordModes()
-		{
-			Caret = CoordModeCaretDefault;
-			Menu = CoordModeMenuDefault;
-			Mouse = CoordModeMouseDefault;
-			Pixel = CoordModePixelDefault;
-			Tooltip = CoordModeToolTipDefault;
-		}
-
-		/// <summary>
-		/// The coordinate mode for caret operations.
-		/// </summary>
-		internal CoordModeType Caret { get; set; }
-
-		/// <summary>
-		/// The coordinate mode for menu operations.
-		/// </summary>
-		internal CoordModeType Menu { get; set; }
-
-		/// <summary>
-		/// The coordinate mode for mouse operations.
-		/// </summary>
-		internal CoordModeType Mouse { get; set; }
-
-		/// <summary>
-		/// The coordinate mode for pixel operations.
-		/// </summary>
-		internal CoordModeType Pixel { get; set; }
-
-		/// <summary>
-		/// The coordinate mode for tool tip operations.
-		/// </summary>
-		internal CoordModeType Tooltip { get; set; }
-
-		/// <summary>
-		/// Retrieves the coordinate mode for the specified operation.
-		/// </summary>
-		/// <param name="mode">The operation to retrieve the coordinate mode for.</param>
-		/// <returns>The coordinate mode for the specified operation.</returns>
-		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if an invalid coordinate operation is specified.</exception>
-		internal CoordModeType GetCoordMode(CoordMode mode)
-		{
-			return mode switch
-		{
-				CoordMode.Caret => Caret,
-				CoordMode.Menu => Menu,
-				CoordMode.Mouse => Mouse,
-				CoordMode.Pixel => Pixel,
-				CoordMode.Tooltip => Tooltip,
-				_ => (CoordModeType)Errors.ValueErrorOccurred($"Invalid coordinate mode type: {mode}", null, CoordModeType.Client)
-			};
 		}
 	}
 

--- a/Keysharp.Core/Core/Screen.cs
+++ b/Keysharp.Core/Core/Screen.cs
@@ -174,7 +174,7 @@ namespace Keysharp.Core
 
 			if (location.HasValue)
 			{
-				location = Mouse.RevertPoint(location.Value, Script.TheScript.Coords.Mouse);
+				location = Mouse.RevertPoint(location.Value, ThreadAccessors.A_CoordModePixel);
 				outX = (long)location.Value.X;
 				outY = (long)location.Value.Y;
 			}
@@ -291,7 +291,7 @@ namespace Keysharp.Core
 
 			if (location.HasValue)
 			{
-				location = Mouse.RevertPoint(location.Value, Script.TheScript.Coords.Mouse);
+				location = Mouse.RevertPoint(location.Value, ThreadAccessors.A_CoordModePixel);
 				outX = (long)location.Value.X;
 				outY = (long)location.Value.Y;
 				return 1L;

--- a/Keysharp.Core/Scripting/Script/Script.cs
+++ b/Keysharp.Core/Scripting/Script/Script.cs
@@ -128,7 +128,6 @@ namespace Keysharp.Scripting
 		internal ComMethodData ComMethodData => comMethodData ?? (comMethodData = new ());
 #endif
 		internal ControlProvider ControlProvider => controlProvider ?? (controlProvider = new ());
-		internal CoordModes Coords { get; private set; }
 		internal DelegateData DelegateData => delegateData ?? (delegateData = new ());
 #if WINDOWS
 		internal DllData DllData => dllData ?? (dllData = new ());
@@ -222,8 +221,6 @@ namespace Keysharp.Scripting
 			LoadDlls();
 			Application.AddMessageFilter(new MessageFilter());
 			_ = InitHook();//Why is this always being initialized even when there are no hooks? This is very inefficient.//TODO
-			//Init the data objects that the API classes will use.
-			Coords = Threads.GetThreadVariables().Coords;
 			//Init the API classes, passing in this which will be used to access their respective data objects.
 			Reflections = new ();
 			SetInitialFloatFormat();//This must be done intially and not just when A_FormatFloat is referenced for the first time.
@@ -382,6 +379,7 @@ namespace Keysharp.Scripting
 			_ = mainWindow.BeginInvoke(() =>
 			{
 				var ret = Threads.BeginThread();
+				ret.Item2.configData = AccessorData.threadConfigDataPrototype;
 
 				if (!Flow.TryCatch(() =>
 				{

--- a/Keysharp.Core/Windows/WindowItem.cs
+++ b/Keysharp.Core/Windows/WindowItem.cs
@@ -268,7 +268,7 @@ namespace Keysharp.Core.Windows
 					return [];
 
 				var items = new List<string>(64);
-				var tv = Script.TheScript.Threads.GetThreadVariables();
+				var tv = Script.TheScript.Threads.GetThreadVariables().configData;
 				_ = WindowsAPI.EnumChildWindows(Handle, (nint hwnd, int lParam) =>
 				{
 					if (tv.detectHiddenText || WindowsAPI.IsWindowVisible(hwnd))

--- a/Keysharp.Core/Windows/WindowManager.cs
+++ b/Keysharp.Core/Windows/WindowManager.cs
@@ -60,7 +60,7 @@ namespace Keysharp.Core.Windows
 			if (criteria.IsEmpty)
 				return found;
 
-			var mm = Script.TheScript.Threads.GetThreadVariables().titleMatchMode;
+			var mm = ThreadAccessors.A_TitleMatchMode;
 
 			if (mm < 4) //If the matching mode is not RegEx then try to take an optimized path
 			{

--- a/Keysharp.Core/Windows/WindowsKeyboardMouseSender.cs
+++ b/Keysharp.Core/Windows/WindowsKeyboardMouseSender.cs
@@ -1799,7 +1799,7 @@ namespace Keysharp.Core.Windows
 			var modifiersLRSpecified = (modifiersLR | modifiersLRPersistent);
 			var script = Script.TheScript;
 			var vkIsMouse = script.HookThread.IsMouseVK(vk); // Caller has ensured that VK is non-zero when it wants a mouse click.
-			var tv = script.Threads.GetThreadVariables();
+			var tv = script.Threads.GetThreadVariables().configData;
 			var sendLevel = tv.sendLevel;
 
 			for (var i = 0L; i < repeatCount; ++i)
@@ -2002,7 +2002,7 @@ namespace Keysharp.Core.Windows
 				sub = sub.Slice(6);
 			}
 
-			var tv = script.Threads.GetThreadVariables();
+			var tv = script.Threads.GetThreadVariables().configData;
 			var origKeyDelay = tv.keyDelay;
 			var origPressDuration = tv.keyDuration;
 

--- a/Keysharp.Tests/Code/flow-realthreads.ahk
+++ b/Keysharp.Tests/Code/flow-realthreads.ahk
@@ -72,3 +72,44 @@ If tot == 10000
 	FileAppend, "pass", "*"
 else
 	FileAppend, "fail", "*"
+
+CoordMode "Mouse", "Screen"
+
+StartRealThread(RealThreadEntry)
+
+cb2 := CallbackCreate(SetCoordModeMouseClient)
+Loop 10000 {
+	DllCall(cb2)
+}
+
+if A_CoordModeMouse = "Screen"
+	FileAppend "pass", "*"
+else
+	FileAppend "fail", "*"
+
+RealThreadEntry() {
+	CoordMode "Mouse", "Screen"
+	cb1 := CallbackCreate(SetCoordModeMouseWindow)
+
+	Loop 10000 {
+		DllCall(cb1)
+	}
+}
+
+SetCoordModeMouseWindow() {
+	if A_CoordModeMouse = "Client" {
+		FileAppend "fail", "*"
+		ExitApp()
+	}
+
+	CoordMode "Mouse", "Window"
+}
+
+SetCoordModeMouseClient() {
+	if A_CoordModeMouse = "Window" {
+		FileAppend "fail", "*"
+		ExitApp()
+	}
+
+	CoordMode "Mouse", "Client"
+}

--- a/Keysharp.Tests/Code/props-script-settings.ahk
+++ b/Keysharp.Tests/Code/props-script-settings.ahk
@@ -598,4 +598,36 @@ Suspend, true
 if (A_IsSuspended == true) 
 	FileAppend, "pass", "*"
 else
-	FileAppend, "fail", "*"
+	FileAppend "fail", "*"
+
+CoordMode "Mouse", "Screen"
+
+DllCall(CallbackCreate(SetCoordModeMouse)) ; Execute in new pseudo-thread
+
+if (A_CoordModeMouse = "Screen")
+	FileAppend "pass", "*"
+else
+	FileAppend "fail", "*"
+
+DllCall(CallbackCreate(CheckCoordModeMouse))
+
+SetCoordModeMouse() {
+	if (A_CoordModeMouse = "Screen")
+		FileAppend "pass", "*"
+	else
+		FileAppend "fail", "*"
+
+	CoordMode("Mouse", "Window")
+
+	if (A_CoordModeMouse = "Window")
+		FileAppend "pass", "*"
+	else
+		FileAppend "fail", "*"
+}
+
+CheckCoordModeMouse() {
+	if (A_CoordModeMouse = "Screen")
+		FileAppend "pass", "*"
+	else
+		FileAppend "fail", "*"
+}


### PR DESCRIPTION
With this PR the auto-execute section uses a prototype instance of thread configuration variables, which is then copied over by all new pseudo-threads. This makes the behavior of such variables consistent with AHK. The new unit test in props-script-settings.ahk demonstrates which bug it fixes.