### PR TITLE
Threads & GUI fixes

### DIFF
--- a/Keysharp.Core/Common/Keyboard/HotkeyDefinition.cs
+++ b/Keysharp.Core/Common/Keyboard/HotkeyDefinition.cs
@@ -1933,7 +1933,7 @@ namespace Keysharp.Core.Common.Keyboard
 				maxThreads = A_MaxThreadsPerHotkey.Aui(),    // The values of these can vary during load-time.
 				maxThreadsBuffer = A_MaxThreadsBuffer.Ab(),
 				inputLevel = (uint)A_InputLevel,
-				hotCriterion = Script.TheScript.Threads.GetThreadVariables().hotCriterion, // If this hotkey is an alt-tab one (mHookAction), this is stored but ignored until/unless the Hotkey command converts it into a non-alt-tab hotkey.
+				hotCriterion = Script.TheScript.Threads.CurrentThread.hotCriterion, // If this hotkey is an alt-tab one (mHookAction), this is stored but ignored until/unless the Hotkey command converts it into a non-alt-tab hotkey.
 				suspendExempt = A_SuspendExempt.Ab(),
 				noSuppress = _noSuppress,
 				enabled = true
@@ -2037,7 +2037,7 @@ namespace Keysharp.Core.Common.Keyboard
 		/// <returns></returns>
 		internal HotkeyVariant FindVariant()
 		{
-			var tv = Script.TheScript.Threads.GetThreadVariables();
+			var tv = Script.TheScript.Threads.CurrentThread;
 
 			for (var vp = firstVariant; vp != null; vp = vp.nextVariant)
 				if (vp.hotCriterion == tv.hotCriterion)

--- a/Keysharp.Core/Common/Keyboard/HotkeyDefinition.cs
+++ b/Keysharp.Core/Common/Keyboard/HotkeyDefinition.cs
@@ -290,10 +290,10 @@ namespace Keysharp.Core.Common.Keyboard
 				if (cp == null && funcobj != null)
 					AddHotkeyIfExpr(cp = funcobj);
 
-				script.Threads.GetThreadVariables().hotCriterion = cp;
+				script.Threads.CurrentThread.hotCriterion = cp;
 			}
 			else
-				script.Threads.GetThreadVariables().hotCriterion = null;
+				script.Threads.CurrentThread.hotCriterion = null;
 
 			return DefaultObject;
 		}
@@ -1932,7 +1932,7 @@ namespace Keysharp.Core.Common.Keyboard
 				originalCallback = Proc,
 				maxThreads = A_MaxThreadsPerHotkey.Aui(),    // The values of these can vary during load-time.
 				maxThreadsBuffer = A_MaxThreadsBuffer.Ab(),
-				inputLevel = (uint)A_InputLevel,
+				inputLevel = (long)A_InputLevel,
 				hotCriterion = Script.TheScript.Threads.CurrentThread.hotCriterion, // If this hotkey is an alt-tab one (mHookAction), this is stored but ignored until/unless the Hotkey command converts it into a non-alt-tab hotkey.
 				suspendExempt = A_SuspendExempt.Ab(),
 				noSuppress = _noSuppress,
@@ -2150,7 +2150,7 @@ namespace Keysharp.Core.Common.Keyboard
 
 				A_SendLevel = variant.inputLevel;
 				var script = Script.TheScript;
-				var tv = script.Threads.GetThreadVariables();
+				var tv = script.Threads.CurrentThread;
 				tv.hwndLastUsed = new nint(critFoundHwnd);
 				tv.hotCriterion = variant.hotCriterion;
 				object ret = null;
@@ -2413,10 +2413,10 @@ namespace Keysharp.Core.Common.Keyboard
 				if (FindHotkeyCriterion(bf) == null)
 					AddHotkeyCriterion(bf);
 
-				script.Threads.GetThreadVariables().hotCriterion = bf;
+				script.Threads.CurrentThread.hotCriterion = bf;
 			}
 			else
-				script.Threads.GetThreadVariables().hotCriterion = null;
+				script.Threads.CurrentThread.hotCriterion = null;
 
 			return null;
 		}

--- a/Keysharp.Core/Common/Keyboard/HotstringDefinition.cs
+++ b/Keysharp.Core/Common/Keyboard/HotstringDefinition.cs
@@ -74,7 +74,7 @@
 			var script = Script.TheScript;
 			var hm = script.HotstringManager;
 			funcObj = _funcObj;
-			hotCriterion = script.Threads.GetThreadVariables().hotCriterion;
+			hotCriterion = script.Threads.CurrentThread.hotCriterion;
 			suspended = _suspend;
 			maxThreads = A_MaxThreadsPerHotkey.Aui();  // The value of g_MaxThreadsPerHotkey can vary during load-time.
 			priority = hm.hsPriority;
@@ -358,7 +358,7 @@
 
 			// For the following, mSendMode isn't checked because the backup/restore is needed to varying extents
 			// by every mode.
-			var tv = script.Threads.GetThreadVariables().configData;
+			var tv = script.Threads.CurrentThread.configData;
 			var oldDelay = tv.keyDelay;
 			var oldPressDuration = tv.keyDuration;
 			var oldDelayPlay = tv.keyDelayPlay;
@@ -416,7 +416,7 @@
 			if (!AnyThreadsAvailable())//Then test local thread count.
 				return ResultType.Fail;
 
-			var tv = script.Threads.GetThreadVariables();
+			var tv = script.Threads.CurrentThread;
 
 			if (priority < tv.priority)//Finally, test priority.
 				return ResultType.Fail;
@@ -427,7 +427,7 @@
 				var ok = Flow.TryCatch(() =>
 				{
 					ret = null;
-					var tv = script.Threads.GetThreadVariables();
+					var tv = script.Threads.CurrentThread;
 					tv.configData.sendLevel = inputLevel;
 					tv.hwndLastUsed = hwndCritFound;
 					tv.hotCriterion = hotCriterion;// v2: Let the Hotkey command use the criterion of this hotstring by default.

--- a/Keysharp.Core/Common/Keyboard/KeyboardMouseSender.cs
+++ b/Keysharp.Core/Common/Keyboard/KeyboardMouseSender.cs
@@ -366,7 +366,7 @@
 					return;
 				}
 
-				var tv = script.Threads.GetThreadVariables();
+				var tv = script.Threads.CurrentThread;
 
 				// Now that above has ensured variant is non-NULL:
 				if (variant.priority >= tv.priority)//Finally, test priority.

--- a/Keysharp.Core/Common/Threading/Threads.cs
+++ b/Keysharp.Core/Common/Threading/Threads.cs
@@ -13,6 +13,8 @@
 		/// </summary>
 		private readonly ThreadVariableManager tvm = new ((int)Script.TheScript.MaxThreadsTotal + 1);
 
+		internal ThreadVariables CurrentThread;
+
 		int _timersPaused = 0;
 
 		public Threads()
@@ -91,6 +93,8 @@
 				return (success, tv);
 			}
 
+			CurrentThread = tv;
+
 			//We successfully pushed—and if inc == true, we’ve already counted it
 			tv.task = true;
 			return (true, tv);
@@ -147,7 +151,7 @@
 			if (Volatile.Read(ref script.totalExistingThreads) == 0)//Before _ks_UserMainCode() starts to run.1
 				return true;
 
-			var tv = GetThreadVariables();
+			var tv = CurrentThread;
 
 			if (!tv.isCritical//Added this whereas AHK doesn't check it. We should never make a critical thread interruptible.
 					&& !tv.allowThreadToBeInterrupted // Those who check whether g->AllowThreadToBeInterrupted==false should then check whether it should be made true.
@@ -222,6 +226,10 @@
 			}
 		}
 
-		internal void PopThreadVariables(bool pushed, bool checkThread = false) => tvm.PopThreadVariables(pushed, checkThread);
+		internal void PopThreadVariables(bool pushed, bool checkThread = false)
+		{
+			tvm.PopThreadVariables(pushed, checkThread);
+			CurrentThread = GetThreadVariables();
+		}
 	}
 }

--- a/Keysharp.Core/Common/Window/MessageFilter.cs
+++ b/Keysharp.Core/Common/Window/MessageFilter.cs
@@ -8,7 +8,7 @@
 			
 			if (script.GuiData.onMessageHandlers.TryGetValue(m.Msg, out var monitor))
 			{
-				var tv = script.Threads.GetThreadVariables();
+				var tv = script.Threads.CurrentThread;
 
 				if (!script.Threads.AnyThreadsAvailable() || tv.priority > 0)
 					return false;

--- a/Keysharp.Core/Core/Accessors.cs
+++ b/Keysharp.Core/Core/Accessors.cs
@@ -753,7 +753,7 @@
 		{
 			get
 			{
-				var tv = Script.TheScript.Threads.GetThreadVariables();
+				var tv = Script.TheScript.Threads.CurrentThread;
 				return tv.isCritical ? tv.configData.peekFrequency : 0L;
 			}
 		}
@@ -2169,8 +2169,8 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
 		public static CoordModeType A_CoordModeCaret
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.coordModeCaret;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.coordModeCaret = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.coordModeCaret;
+			set => Script.TheScript.Threads.CurrentThread.configData.coordModeCaret = value;
 		}
 
 		/// <summary>
@@ -2179,8 +2179,8 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
 		public static CoordModeType A_CoordModeMenu
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.coordModeMenu;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.coordModeMenu = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.coordModeMenu;
+			set => Script.TheScript.Threads.CurrentThread.configData.coordModeMenu = value;
 		}
 
 		/// <summary>
@@ -2189,8 +2189,8 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
 		public static CoordModeType A_CoordModeMouse
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.coordModeMouse;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.coordModeMouse = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.coordModeMouse;
+			set => Script.TheScript.Threads.CurrentThread.configData.coordModeMouse = value;
 		}
 
 		/// <summary>
@@ -2199,8 +2199,8 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
 		public static CoordModeType A_CoordModePixel
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.coordModePixel;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.coordModePixel = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.coordModePixel;
+			set => Script.TheScript.Threads.CurrentThread.configData.coordModePixel = value;
 		}
 
 		/// <summary>
@@ -2209,8 +2209,8 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if the value couldn't be converted to a <see cref="CoordModeType"/>.</exception>
 		public static CoordModeType A_CoordModeToolTip
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.coordModeToolTip;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.coordModeToolTip = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.coordModeToolTip;
+			set => Script.TheScript.Threads.CurrentThread.configData.coordModeToolTip = value;
 		}
 
 		/// <summary>
@@ -2248,8 +2248,8 @@
 		/// </summary>
 		public static long A_DefaultMouseSpeed
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.defaultMouseSpeed;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.defaultMouseSpeed = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.defaultMouseSpeed;
+			set => Script.TheScript.Threads.CurrentThread.configData.defaultMouseSpeed = value;
 		}
 
 		/// <summary>
@@ -2258,8 +2258,8 @@
 		/// </summary>
 		internal static long A_ControlDelay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.controlDelay;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.controlDelay = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.controlDelay;
+			set => Script.TheScript.Threads.CurrentThread.configData.controlDelay = value;
 		}
 
 		/// <summary>
@@ -2267,8 +2267,8 @@
 		/// </summary>
 		internal static bool A_DetectHiddenText
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.detectHiddenText;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.detectHiddenText = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.detectHiddenText;
+			set => Script.TheScript.Threads.CurrentThread.configData.detectHiddenText = value;
 		}
 
 		/// <summary>
@@ -2276,8 +2276,8 @@
 		/// </summary>
 		internal static bool A_DetectHiddenWindows
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.detectHiddenWindows;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.detectHiddenWindows = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.detectHiddenWindows;
+			set => Script.TheScript.Threads.CurrentThread.configData.detectHiddenWindows = value;
 		}
 
 		/// <summary>
@@ -2285,8 +2285,8 @@
 		/// </summary>
 		internal static object A_EventInfo
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().eventInfo;
-			set => Script.TheScript.Threads.GetThreadVariables().eventInfo = value;
+			get => Script.TheScript.Threads.CurrentThread.eventInfo;
+			set => Script.TheScript.Threads.CurrentThread.eventInfo = value;
 		}
 
 		/// <summary>
@@ -2314,22 +2314,22 @@
 			}
 			set
 			{
-				Script.TheScript.Threads.GetThreadVariables().configData.fileEncoding = value is Encoding enc ? enc : Files.GetEncoding(value.ToString());
+				Script.TheScript.Threads.CurrentThread.configData.fileEncoding = value is Encoding enc ? enc : Files.GetEncoding(value.ToString());
 			}
 		}
 
 		/// <summary>
 		/// Wrapper to retrieve the file encoding as an <see cref="Encoding"/> object.
 		/// </summary>
-		internal static Encoding A_FileEncodingRaw => Script.TheScript.Threads.GetThreadVariables().configData.fileEncoding;
+		internal static Encoding A_FileEncodingRaw => Script.TheScript.Threads.CurrentThread.configData.fileEncoding;
 
 		/// <summary>
 		/// The delay in milliseconds between SendEvent keystrokes.
 		/// </summary>
 		internal static long A_KeyDelay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.keyDelay;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.keyDelay = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.keyDelay;
+			set => Script.TheScript.Threads.CurrentThread.configData.keyDelay = value;
 		}
 
 		/// <summary>
@@ -2337,8 +2337,8 @@
 		/// </summary>
 		internal static long A_KeyDelayPlay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.keyDelayPlay;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.keyDelayPlay = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.keyDelayPlay;
+			set => Script.TheScript.Threads.CurrentThread.configData.keyDelayPlay = value;
 		}
 
 		/// <summary>
@@ -2346,8 +2346,8 @@
 		/// </summary>
 		internal static long A_KeyDuration
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.keyDuration;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.keyDuration = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.keyDuration;
+			set => Script.TheScript.Threads.CurrentThread.configData.keyDuration = value;
 		}
 
 		/// <summary>
@@ -2355,8 +2355,8 @@
 		/// </summary>
 		internal static long A_KeyDurationPlay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.keyDurationPlay;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.keyDurationPlay = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.keyDurationPlay;
+			set => Script.TheScript.Threads.CurrentThread.configData.keyDurationPlay = value;
 		}
 
 		/// <summary>
@@ -2364,8 +2364,8 @@
 		/// </summary>
 		internal static long A_MouseDelay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.mouseDelay;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.mouseDelay = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.mouseDelay;
+			set => Script.TheScript.Threads.CurrentThread.configData.mouseDelay = value;
 		}
 
 		/// <summary>
@@ -2373,8 +2373,8 @@
 		/// </summary>
 		internal static long A_MouseDelayPlay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.mouseDelayPlay;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.mouseDelayPlay = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.mouseDelayPlay;
+			set => Script.TheScript.Threads.CurrentThread.configData.mouseDelayPlay = value;
 		}
 
 		/// <summary>
@@ -2382,8 +2382,8 @@
 		/// Unused because Keysharp is compiled and not interpreted.
 		internal static long A_PeekFrequency
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.peekFrequency;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.peekFrequency = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.peekFrequency;
+			set => Script.TheScript.Threads.CurrentThread.configData.peekFrequency = value;
 		}
 
 #if WINDOWS
@@ -2393,8 +2393,8 @@
 		/// </summary>
 		internal static long A_RegView
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.regView;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.regView = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.regView;
+			set => Script.TheScript.Threads.CurrentThread.configData.regView = value;
 		}
 
 #endif
@@ -2405,8 +2405,8 @@
 		/// </summary>
 		internal static long A_SendLevel
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.sendLevel;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.sendLevel = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.sendLevel;
+			set => Script.TheScript.Threads.CurrentThread.configData.sendLevel = value;
 		}
 
 		/// <summary>
@@ -2415,8 +2415,8 @@
 		/// </summary>
 		internal static SendModes A_SendMode
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.sendMode;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.sendMode = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.sendMode;
+			set => Script.TheScript.Threads.CurrentThread.configData.sendMode = value;
 		}
 
 		/// <summary>
@@ -2424,20 +2424,20 @@
 		/// </summary>
 		internal static bool A_StoreCapsLockMode
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.storeCapsLockMode;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.storeCapsLockMode = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.storeCapsLockMode;
+			set => Script.TheScript.Threads.CurrentThread.configData.storeCapsLockMode = value;
 		}
 
 		internal static long A_TitleMatchMode
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.titleMatchMode;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.titleMatchMode = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.titleMatchMode;
+			set => Script.TheScript.Threads.CurrentThread.configData.titleMatchMode = value;
 		}
 
 		internal static bool A_TitleMatchModeSpeed
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.titleMatchModeSpeed;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.titleMatchModeSpeed = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.titleMatchModeSpeed;
+			set => Script.TheScript.Threads.CurrentThread.configData.titleMatchModeSpeed = value;
 		}
 
 		/// <summary>
@@ -2445,8 +2445,8 @@
 		/// </summary>
 		internal static long A_WinDelay
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().configData.winDelay;
-			set => Script.TheScript.Threads.GetThreadVariables().configData.winDelay = value;
+			get => Script.TheScript.Threads.CurrentThread.configData.winDelay;
+			set => Script.TheScript.Threads.CurrentThread.configData.winDelay = value;
 		}
 	}
 }

--- a/Keysharp.Core/Core/Debug.cs
+++ b/Keysharp.Core/Core/Debug.cs
@@ -12,7 +12,7 @@
 
 			var script = Script.TheScript;
 			var title = script.mainWindow != null ? script.mainWindow.Text : "";
-			var tv = script.Threads.GetThreadVariables().configData;
+			var tv = script.Threads.CurrentThread.configData;
 			var mm = tv.titleMatchMode;
 			tv.titleMatchMode = 2L;//Match anywhere.
 			var hwnd = WindowX.WinExist(A_ScriptName, "", title, "");

--- a/Keysharp.Core/Core/Flow.cs
+++ b/Keysharp.Core/Core/Flow.cs
@@ -30,7 +30,7 @@ namespace Keysharp.Core
 		{
 			var script = Script.TheScript;
 			script.FlowData.callingCritical = true;
-			var tv = script.Threads.GetThreadVariables();
+			var tv = script.Threads.CurrentThread;
 			var on = onOffNumeric == null;
 			long freq = !on ? (onOffNumeric.ParseLong(false) ?? 0L) : 0L;
 
@@ -306,7 +306,7 @@ namespace Keysharp.Core
 			{
 			}
 			else if (f == null)
-				timer = script.Threads.GetThreadVariables().currentTimer;//This means: use the timer which has already been created for this thread/timer event which we are currently inside of.
+				timer = script.Threads.CurrentThread.currentTimer;//This means: use the timer which has already been created for this thread/timer event which we are currently inside of.
 
 			if (timer != null)
 			{
@@ -385,7 +385,7 @@ namespace Keysharp.Core
 				}
 
 				var pri = t.Tag.Ai();
-				var tv = v.GetThreadVariables();
+				var tv = v.CurrentThread;
 
 				if (pri >= tv.priority)
 				{
@@ -553,7 +553,7 @@ namespace Keysharp.Core
 			if (string.Compare(sf, "notimers", true) == 0)
 				A_AllowTimers = !(Options.OnOff(value1.As()) ?? false);
 			else if (string.Compare(sf, "priority", true) == 0)
-				script.Threads.GetThreadVariables().priority = value1.Al();
+				script.Threads.CurrentThread.priority = value1.Al();
 			else if (string.Compare(sf, "interrupt", true) == 0)
 				script.uninterruptibleTime = value1.Ai(script.uninterruptibleTime);
 

--- a/Keysharp.Core/Core/Gui/Gui.cs
+++ b/Keysharp.Core/Core/Gui/Gui.cs
@@ -859,6 +859,7 @@
 					tv.CheckBoxes = opts.ischecked.HasValue && opts.ischecked.Value != 0;
 					tv.ShowLines = opts.lines ?? true;
 					tv.LabelEdit = opts.rdonly.IsFalse();
+					tv.HideSelection = false;
 
 					if (tv.LabelEdit && !opts.wantf2.IsFalse())//Note that checking !IsFalse() is not the same as IsTrue().
 						tv.KeyDown += Tv_Lv_KeyDown;

--- a/Keysharp.Core/Core/Gui/GuiControl.cs
+++ b/Keysharp.Core/Core/Gui/GuiControl.cs
@@ -566,12 +566,18 @@
 						var strs = obj.Cast<object>().Skip(1).Select(x => x.Str()).ToList();
 						result = ListViewHelper.AddOrInsertListViewItem(lv, lvo, strs, int.MinValue);
 					}
-					else if (_control is KeysharpListBox lb)//Using AddRange() relieves the caller of having to set -Redraw first.
-						lb.Items.AddRange(obj.Cast<object>().Select(x => x.Str()).ToArray());
-					else if (_control is KeysharpComboBox cb)
-						cb.Items.AddRange(obj.Cast<object>().Select(x => x.Str()).ToArray());
-					else if (_control is KeysharpTabControl tc)
-						tc.TabPages.AddRange(obj.Cast<object>().Select(x => new TabPage(x.Str())).ToArray());
+					else
+					{
+						if (obj.Length > 0 && obj[0] is Array arr)
+							obj = arr.array.ToArray();
+
+						if (_control is KeysharpListBox lb)//Using AddRange() relieves the caller of having to set -Redraw first.
+							lb.Items.AddRange(obj.Cast<object>().Select(x => x.Str()).ToArray());
+						else if (_control is KeysharpComboBox cb)
+							cb.Items.AddRange(obj.Cast<object>().Select(x => x.Str()).ToArray());
+						else if (_control is KeysharpTabControl tc)
+							tc.TabPages.AddRange(obj.Cast<object>().Select(x => new TabPage(x.Str())).ToArray());
+					}
 				}
 				finally
 				{
@@ -994,7 +1000,7 @@
 			public long Modify(object rowNumber, object options = null, params object[] obj)
 			{
 				var opts = options == null ? null : options.ToString();
-				var rownumber = rowNumber.Ai();
+				var rownumber = rowNumber.Al();
 
 				if (_control is KeysharpTreeView tv)
 				{
@@ -1027,7 +1033,7 @@
 
 							for (rownumber = start; rownumber < end; rownumber++)
 							{
-								var item = lv.Items[rownumber];
+								var item = lv.Items[(int)rownumber];
 
 								for (int i = 0, j = lvo.colstart; i < strs.Count && j < item.SubItems.Count; i++, j++)
 									item.SubItems[j].Text = strs[i];

--- a/Keysharp.Core/Core/Gui/GuiHelper.cs
+++ b/Keysharp.Core/Core/Gui/GuiHelper.cs
@@ -4,14 +4,14 @@
 	{
 		internal static string DefaultGuiId
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().defaultGui ?? "1";
-			set => Script.TheScript.Threads.GetThreadVariables().defaultGui = value;
+			get => Script.TheScript.Threads.CurrentThread.defaultGui ?? "1";
+			set => Script.TheScript.Threads.CurrentThread.defaultGui = value;
 		}
 
 		internal static Form DialogOwner
 		{
-			get => Script.TheScript.Threads.GetThreadVariables().dialogOwner;
-			set => Script.TheScript.Threads.GetThreadVariables().dialogOwner = value;
+			get => Script.TheScript.Threads.CurrentThread.dialogOwner;
+			set => Script.TheScript.Threads.CurrentThread.dialogOwner = value;
 		}
 
 		public static Gui Gui(object obj0 = null, object obj1 = null, object obj2 = null) => new ([obj0, obj1, obj2]);

--- a/Keysharp.Core/Core/Gui/TreeViewHelper.cs
+++ b/Keysharp.Core/Core/Gui/TreeViewHelper.cs
@@ -56,7 +56,7 @@
 								tv.RemoveMarkForExpansion(node);
 							}
 						}
-						else if (opt.Equals("Select ", StringComparison.OrdinalIgnoreCase)) { tv.SelectedNode = node; }
+						else if (opt.Equals("Select", StringComparison.OrdinalIgnoreCase)) { tv.SelectedNode = node; }
 						else if (opt.Equals("Vis", StringComparison.OrdinalIgnoreCase)) { node.EnsureVisible(); }
 						else if (opt.Equals("VisFirst", StringComparison.OrdinalIgnoreCase)) { node.EnsureVisible(); tv.TopNode = node; }
 						else if (Options.TryParse(opt, "Icon", ref icon))

--- a/Keysharp.Core/Core/Gui/WindowX.cs
+++ b/Keysharp.Core/Core/Gui/WindowX.cs
@@ -1047,7 +1047,7 @@ namespace Keysharp.Core
 									 object excludeTitle = null,
 									 object excludeText = null)
 		{
-			var tv = Script.TheScript.Threads.GetThreadVariables().configData;
+			var tv = Script.TheScript.Threads.CurrentThread.configData;
 			var prev = tv.detectHiddenWindows;
 			tv.detectHiddenWindows = true;
 			SearchWindows(winTitle, winText, excludeTitle, excludeText).ForEach(win => win.Show());

--- a/Keysharp.Core/Core/Keyboard.cs
+++ b/Keysharp.Core/Core/Keyboard.cs
@@ -234,7 +234,7 @@ namespace Keysharp.Core
 			{
 				fo = Functions.GetFuncObj(action, null);//Don't throw on failure because returning null is a valid action.
 				var script = Script.TheScript;
-				var tv = script.Threads.GetThreadVariables();
+				var tv = script.Threads.CurrentThread;
 
 				if (fo == null && !string.IsNullOrEmpty(label) && ((hook_action = HotkeyDefinition.ConvertAltTab(label, true)) == 0))
 				{
@@ -395,7 +395,7 @@ break_twice:;
 				return Errors.ValueErrorOccurred($"Invalid value of {obj2} for parameter 3.");
 
 			bool wasAlreadyEnabled;
-			var tv = script.Threads.GetThreadVariables();
+			var tv = script.Threads.CurrentThread;
 			var existing = hm.FindHotstring(hotstringStart, caseSensitive, detectInsideWord, tv.hotCriterion);
 
 			if (existing != null)

--- a/Keysharp.Core/Core/Loops.cs
+++ b/Keysharp.Core/Core/Loops.cs
@@ -812,7 +812,7 @@ namespace Keysharp.Core
 		/// <returns>Non negative number on success, else negative.</returns>
 		private static long QueryInfoKey(RegistryKey regkey)
 		{
-			var tv = Script.TheScript.Threads.GetThreadVariables();
+			var tv = Script.TheScript.Threads.CurrentThread;
 
 			if (tv.RegSb.Length > 0)
 				_ = tv.RegSb.Clear();

--- a/Keysharp.Core/Core/Math.cs
+++ b/Keysharp.Core/Core/Math.cs
@@ -23,7 +23,7 @@
 		/// <param name="obj">The numerical seed to create the random number generator with.</param>
 		public static object RandomSeed(object obj)
 		{
-			Script.TheScript.Threads.GetThreadVariables().RandomGenerator = new Random(obj.Ai());
+			Script.TheScript.Threads.CurrentThread.RandomGenerator = new Random(obj.Ai());
 			return DefaultObject;
 		}
 
@@ -53,7 +53,7 @@
 		/// <summary>
 		/// Internal helper to get a random number generator for the current thread.
 		/// </summary>
-		private static Random RandomGenerator => Script.TheScript.Threads.GetThreadVariables().RandomGenerator;
+		private static Random RandomGenerator => Script.TheScript.Threads.CurrentThread.RandomGenerator;
 
 		/// <summary>
 		/// Returns the absolute value of a number.

--- a/Keysharp.Core/Linux/WindowItem.cs
+++ b/Keysharp.Core/Linux/WindowItem.cs
@@ -406,7 +406,7 @@ namespace Keysharp.Core.Linux
 
 				var prop = new XTextProperty();
 				var attr = new XWindowAttributes();
-				var tv = Script.TheScript.Threads.GetThreadVariables();
+				var tv = Script.TheScript.Threads.CurrentThread;
 				var doHidden = ThreadAccessors.A_DetectHiddenWindows;
 				var filter = (long id) =>
 				{

--- a/Keysharp.Core/Scripting/Script/Script.cs
+++ b/Keysharp.Core/Scripting/Script/Script.cs
@@ -142,8 +142,8 @@ namespace Keysharp.Scripting
 
 		internal long HwndLastUsed
 		{
-			get => Threads.GetThreadVariables().hwndLastUsed;
-			set => Threads.GetThreadVariables().hwndLastUsed = value;
+			get => Threads.CurrentThread.hwndLastUsed;
+			set => Threads.CurrentThread.hwndLastUsed = value;
 		}
 
 		internal ImageListData ImageListData => imageListData ?? (imageListData = new ());

--- a/Keysharp.Core/Windows/WindowItem.cs
+++ b/Keysharp.Core/Windows/WindowItem.cs
@@ -268,7 +268,7 @@ namespace Keysharp.Core.Windows
 					return [];
 
 				var items = new List<string>(64);
-				var tv = Script.TheScript.Threads.GetThreadVariables().configData;
+				var tv = Script.TheScript.Threads.CurrentThread.configData;
 				_ = WindowsAPI.EnumChildWindows(Handle, (nint hwnd, int lParam) =>
 				{
 					if (tv.detectHiddenText || WindowsAPI.IsWindowVisible(hwnd))

--- a/Keysharp.Core/Windows/WindowsHookThread.cs
+++ b/Keysharp.Core/Windows/WindowsHookThread.cs
@@ -4960,7 +4960,7 @@ namespace Keysharp.Core.Windows
 							// NO BREAK IN ABOVE, FALL INTO NEXT CASE:
 							// ********
 							var script = Script.TheScript;
-							var tv = script.Threads.GetThreadVariables();
+							var tv = script.Threads.CurrentThread;
 							tv.WaitForCriticalToFinish();//Must wait until the previous critical task finished before proceeding.
 
 							switch (msg.message)

--- a/Keysharp.Core/Windows/WindowsKeyboardMouseSender.cs
+++ b/Keysharp.Core/Windows/WindowsKeyboardMouseSender.cs
@@ -1799,7 +1799,7 @@ namespace Keysharp.Core.Windows
 			var modifiersLRSpecified = (modifiersLR | modifiersLRPersistent);
 			var script = Script.TheScript;
 			var vkIsMouse = script.HookThread.IsMouseVK(vk); // Caller has ensured that VK is non-zero when it wants a mouse click.
-			var tv = script.Threads.GetThreadVariables().configData;
+			var tv = script.Threads.CurrentThread.configData;
 			var sendLevel = tv.sendLevel;
 
 			for (var i = 0L; i < repeatCount; ++i)
@@ -2002,7 +2002,7 @@ namespace Keysharp.Core.Windows
 				sub = sub.Slice(6);
 			}
 
-			var tv = script.Threads.GetThreadVariables().configData;
+			var tv = script.Threads.CurrentThread.configData;
 			var origKeyDelay = tv.keyDelay;
 			var origPressDuration = tv.keyDuration;
 


### PR DESCRIPTION
1. Added a `CurrentThread` field to `ThreadVariablesManager` which keeps track of the current pseudo-thread, omitting the need for `GetThreadVariables()` calls.
2. Added `TreeView.HideSelection = false` to TreeView constructor so if the TreeView is unfocused then the selected item selection is still visible.
3. Fixed a typo in handling TreeView "Select" option.
4. Fixed `GuiControl.Add(Array)`, previously only parametric input was handled.