### PR TITLE
Sort Map before enumeration, add HashMap

### DIFF
--- a/Keysharp.Benchmark/MapBench.cs
+++ b/Keysharp.Benchmark/MapBench.cs
@@ -19,7 +19,7 @@ namespace Keysharp.Benchmark
 	public class MapReadBenchmark : BaseTest
 	{
 		private Dictionary<object, object> dkt = [];
-		private Map map = Collections.Map(), mapScript = Collections.Map();
+		private Map map, mapScript;
 		private List<string> strings = [];
 		private Keysharp.Scripting.Script? _ks_s;
 
@@ -70,7 +70,7 @@ namespace Keysharp.Benchmark
 	public class MapWriteBenchmark : BaseTest
 	{
 		private readonly Dictionary<object, object> dkt = [];
-		private readonly Map map = Collections.Map(), mapScript = Collections.Map();
+		private readonly Map map, mapScript;
 		private readonly List<string> strings = [];
 		private readonly Keysharp.Scripting.Script _ks_s;
 

--- a/Keysharp.Core/Common/Keyboard/HotstringDefinition.cs
+++ b/Keysharp.Core/Common/Keyboard/HotstringDefinition.cs
@@ -88,7 +88,7 @@
 			endCharRequired = hm.hsEndCharRequired;
 			detectWhenInsideWord = hm.hsDetectWhenInsideWord;
 			doReset = hm.hsDoReset;
-			inputLevel = (uint)A_InputLevel;
+			inputLevel = (long)A_InputLevel;
 			suspendExempt = A_SuspendExempt.Ab();
 			constructedOK = false;
 			var unusedX = false; // do not assign  mReplacement if execute_action is true.

--- a/Keysharp.Core/Core/Collections.cs
+++ b/Keysharp.Core/Core/Collections.cs
@@ -49,11 +49,6 @@
 		///     An object[] of key,value pairs.
 		/// </param>
 		/// <returns>A new <see cref="Map"/> object.</returns>
-		public static Map Map(params object[] obj)
-		{
-			var map = new Map();
-			map.Set(obj);
-			return map;
-		}
+		public static Map Map(params object[] obj) => new Map(obj);
 	}
 }

--- a/Keysharp.Core/Core/KeysharpEnhancements.cs
+++ b/Keysharp.Core/Core/KeysharpEnhancements.cs
@@ -91,5 +91,17 @@
 		/// <param name="obj0">The text to send to the debugger for display.</param>
 		/// <param name="obj1">True to first clear the display, else false to append.</param>
 		public static object OutputDebugLine(object obj0, object obj1 = null) => Debug.OutputDebugCommon($"{obj0.As()}{Environment.NewLine}", obj1.Ab());
+
+		/// <summary>
+		/// Creates a new <see cref="HashMap"/> object.
+		/// </summary>
+		/// <param name="obj">The optional data to initialize the <see cref="HashMap"/> with. This can be:<br/>
+		///     An existing <see cref="HashMap"/> object.<br/>
+		///     An <see cref="Array"/> of key,value pairs.<br/>
+		///     An existing <see cref="Dictionary{string, object}"/> object.<br/>
+		///     An object[] of key,value pairs.
+		/// </param>
+		/// <returns>A new <see cref="Map"/> object.</returns>
+		public static HashMap HashMap(params object[] obj) => new HashMap(obj);
 	}
 }

--- a/Keysharp.Core/Core/Map.cs
+++ b/Keysharp.Core/Core/Map.cs
@@ -142,20 +142,13 @@
 		{
 			get
 			{
-				if (isDirty)
+				if (_enumerableMap == null)
 				{
-					isDirty = false;
 					_enumerableMap = map.OrderBy(kv => kv.Key, new MapComparer(caseSense));
 				}
 				return _enumerableMap;
 			}
 		}
-
-		/// <summary>
-		/// Tracks whether any changes have been made to the underlying <see cref="Dictionary"/>
-		/// after the last access of the ordered dictionary.
-		/// </summary>
-		private bool isDirty = true;
 
 		/// <summary>
 		/// The case comparison to use for string keys.
@@ -201,7 +194,8 @@
 
 				if (caseSense != oldVal)
 				{
-					isDirty = true;
+					if (_enumerableMap != null)
+						_enumerableMap = null;
 					map = new Dictionary<object, object>(new CaseEqualityComp(caseSense));
 				}
 			}
@@ -282,7 +276,8 @@
 		/// </summary>
 		public void Clear()
 		{
-			isDirty = true;
+			if (_enumerableMap != null)
+				_enumerableMap = null;
 			map.Clear();
 		}
 
@@ -324,8 +319,8 @@
 		{
 			if (map.Remove(key, out var val))
 			{
-				if (!isDirty)
-					isDirty = true;
+				if (_enumerableMap != null)
+					_enumerableMap = null;
 				return val;
 			}
 
@@ -521,8 +516,9 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if values was not of a supported type.</exception>
 		public void Set(params object[] args)
 		{
-			if (!isDirty)
-				isDirty = true;
+			if (_enumerableMap != null)
+				_enumerableMap = null;
+
 			if (args == null || args.Length == 0)
 			{
 				if (map == null)
@@ -675,8 +671,8 @@
 
 			set
 			{
-				if (!isDirty)
-					isDirty = true;
+				if (_enumerableMap != null)
+					_enumerableMap = null;
 				Insert(key, value);
 			}
 		}

--- a/Keysharp.Core/Core/Map.cs
+++ b/Keysharp.Core/Core/Map.cs
@@ -120,7 +120,7 @@
 		/// </summary>
 		public HashMap(params object[] args) : base(args) { }
 		internal HashMap(bool make__Item, params object[] args) : base(make__Item, args) { }
-		protected override IEnumerable<KeyValuePair<object, object>> enumerableMap => map;
+		protected override IEnumerable<KeyValuePair<object, object>> EnumerableMap => map;
 	}
 
 	/// <summary>
@@ -137,16 +137,16 @@
 		/// <summary>
 		/// The underlying <see cref="Dictionary"/> sorted in the order AHK does it.
 		/// </summary>
-		private IEnumerable<KeyValuePair<object, object>> _enumerableMap;
-		protected virtual IEnumerable<KeyValuePair<object, object>> enumerableMap
+		private IEnumerable<KeyValuePair<object, object>> enumerableMap;
+		protected virtual IEnumerable<KeyValuePair<object, object>> EnumerableMap
 		{
 			get
 			{
-				if (_enumerableMap == null)
+				if (enumerableMap == null)
 				{
-					_enumerableMap = map.OrderBy(kv => kv.Key, new MapComparer(caseSense));
+					enumerableMap = map.OrderBy(kv => kv.Key, new MapComparer(caseSense));
 				}
-				return _enumerableMap;
+				return enumerableMap;
 			}
 		}
 
@@ -194,8 +194,8 @@
 
 				if (caseSense != oldVal)
 				{
-					if (_enumerableMap != null)
-						_enumerableMap = null;
+					if (enumerableMap != null)
+						enumerableMap = null;
 					map = new Dictionary<object, object>(new CaseEqualityComp(caseSense));
 				}
 			}
@@ -252,7 +252,7 @@
 		///     2: Return the key in the first element, and the value in the second.
 		/// </param>
 		/// <returns><see cref="KeysharpEnumerator"/></returns>
-		public KeysharpEnumerator __Enum(object count) => new MapKeyValueIterator(enumerableMap, count.Ai());
+		public KeysharpEnumerator __Enum(object count) => new MapKeyValueIterator(EnumerableMap, count.Ai());
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Map"/> class.
@@ -276,8 +276,8 @@
 		/// </summary>
 		public void Clear()
 		{
-			if (_enumerableMap != null)
-				_enumerableMap = null;
+			if (enumerableMap != null)
+				enumerableMap = null;
 			map.Clear();
 		}
 
@@ -299,7 +299,7 @@
 		{
 			var kvs = new List<object>(map.Count * 2);
 
-			foreach (var kv in enumerableMap)
+			foreach (var kv in EnumerableMap)
 			{
 				kvs.Add(kv.Key);
 				kvs.Add(kv.Value);
@@ -319,8 +319,8 @@
 		{
 			if (map.Remove(key, out var val))
 			{
-				if (_enumerableMap != null)
-					_enumerableMap = null;
+				if (enumerableMap != null)
+					enumerableMap = null;
 				return val;
 			}
 
@@ -359,7 +359,7 @@
 		/// The implementation for <see cref="IEnumerable{(object, object)}.GetEnumerator()"/> which returns an <see cref="MapKeyValueIterator"/>.
 		/// </summary>
 		/// <returns>An <see cref="IEnumerator{(object, object)}"/> which is a <see cref="MapKeyValueIterator"/>.</returns>
-		public IEnumerator<(object, object)> GetEnumerator() => new MapKeyValueIterator(enumerableMap, 2);
+		public IEnumerator<(object, object)> GetEnumerator() => new MapKeyValueIterator(EnumerableMap, 2);
 
 		/// <summary>
 		/// Returns true if the specified key has an associated value within a map, otherwise false.
@@ -425,7 +425,7 @@
 				else
 					_ = sb.Append(indent + name + ": " + "\t {");//Need to put this in multiple steps because the AStyle formatter misinterprets it.
 
-				foreach (var kv in enumerableMap)
+				foreach (var kv in EnumerableMap)
 				{
 					string key;
 
@@ -516,8 +516,8 @@
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if values was not of a supported type.</exception>
 		public void Set(params object[] args)
 		{
-			if (_enumerableMap != null)
-				_enumerableMap = null;
+			if (enumerableMap != null)
+				enumerableMap = null;
 
 			if (args == null || args.Length == 0)
 			{
@@ -593,7 +593,7 @@
 				_ = sb.Append('{');
 				var i = 0;
 
-				foreach (var kv in enumerableMap)
+				foreach (var kv in EnumerableMap)
 				{
 					string key;
 
@@ -627,7 +627,7 @@
 		/// The implementation for <see cref="IEnumerable.GetEnumerator"/> which just calls <see cref="__Enum"/>.
 		/// </summary>
 		/// <returns><see cref="MapKeyValueIterator"/></returns>
-		IEnumerator IEnumerable.GetEnumerator() => new MapKeyValueIterator(enumerableMap, 2);
+		IEnumerator IEnumerable.GetEnumerator() => new MapKeyValueIterator(EnumerableMap, 2);
 		/// <summary>
 		/// Internal helper to insert a key,value pair into the map.
 		/// </summary>
@@ -671,8 +671,8 @@
 
 			set
 			{
-				if (_enumerableMap != null)
-					_enumerableMap = null;
+				if (enumerableMap != null)
+					enumerableMap = null;
 				Insert(key, value);
 			}
 		}

--- a/Keysharp.Tests/Code/collections-map.ahk
+++ b/Keysharp.Tests/Code/collections-map.ahk
@@ -101,7 +101,7 @@ else
 
 str := m.ToString()
 
-if (str == '{"one": 1, "two": 2, "three": 3}')
+if (str == '{"one": 1, "three": 3, "two": 2}')
 	FileAppend, "pass", "*"
 else
 	FileAppend, "fail", "*"
@@ -700,3 +700,20 @@ if (mkey1 == "one" && mval1 == 1 &&
 	FileAppend, "pass", "*"
 else
 	FileAppend, "fail", "*"
+
+; Test correct sorting order
+m := Map(1.0, "double", 1, "integer", "1", "string", {}, "object")
+i := 0
+for k, v in m {
+	i++
+	if (i == 1 && v == "integer")
+		FileAppend "pass", "*"
+	else if (i == 2 && v == "object")
+		FileAppend "pass", "*"
+	else if (i == 3 && v == "string")
+		FileAppend "pass", "*"
+	else if (i == 4 && v == "double")
+		FileAppend "pass", "*"
+	else
+		FileAppend "fail", "*"
+}

--- a/Keysharp.Tests/Code/collections-map.ahk
+++ b/Keysharp.Tests/Code/collections-map.ahk
@@ -717,3 +717,29 @@ for k, v in m {
 	else
 		FileAppend "fail", "*"
 }
+
+a := HashMap() ; Map with a key and property each with the same name.
+a["test"] := 3
+a.test := 2
+
+if (a["test"] == 3)
+	FileAppend, "pass", "*"
+else
+	FileAppend, "fail", "*"
+
+; HashMap should be unsorted, usually in insertion order (although this is an implementation detail)
+m := HashMap(1.0, "double", 1, "integer", "1", "string", {}, "object")
+i := 0
+for k, v in m {
+	i++
+	if (i == 1 && v == "double")
+		FileAppend "pass", "*"
+	else if (i == 2 && v == "integer")
+		FileAppend "pass", "*"
+	else if (i == 3 && v == "string")
+		FileAppend "pass", "*"
+	else if (i == 4 && v == "object")
+		FileAppend "pass", "*"
+	else
+		FileAppend "fail", "*"
+}

--- a/Keysharp.Tests/CollectionsTests.cs
+++ b/Keysharp.Tests/CollectionsTests.cs
@@ -131,18 +131,18 @@ namespace Keysharp.Tests
 			arr.CopyTo(sa, 0);
 			Assert.AreEqual(sa.GetValue(0), "one");
 			Assert.AreEqual(sa.GetValue(1), 1L);
-			Assert.AreEqual(sa.GetValue(2), "two");
-			Assert.AreEqual(sa.GetValue(3), 2L);
-			Assert.AreEqual(sa.GetValue(4), "three");
-			Assert.AreEqual(sa.GetValue(5), 3L);
+			Assert.AreEqual(sa.GetValue(2), "three");
+			Assert.AreEqual(sa.GetValue(3), 3L);
+			Assert.AreEqual(sa.GetValue(4), "two");
+			Assert.AreEqual(sa.GetValue(5), 2L);
 			//
 			sa = new object[3];
 			arr.CopyTo(sa, 0);
 			Assert.AreEqual(sa.GetValue(0), "one");
 			Assert.AreEqual(sa.GetValue(1), 1L);
-			Assert.AreEqual(sa.GetValue(2), "two");
+			Assert.AreEqual(sa.GetValue(2), "three");
 			//
-			Assert.AreEqual(arr.ToString(), "{\"one\": 1, \"two\": 2, \"three\": 3}");
+			Assert.AreEqual(arr.ToString(), "{\"one\": 1, \"three\": 3, \"two\": 2}");
 			Assert.IsTrue(TestScript("collections-map", true));
 		}
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ class class1
 	+ RegEx operator ~= returns a RegExMatchInfo, which is treated as an integer in comparison or math operations
 
 ###	Additions/Improvements: ###
+* `Map` internally uses a real hashmap, which means item access, insertions and removals are faster, which is especially true for larger datasets. To keep at least partial compatibility with AutoHotkey the `Map` object is copied and sorted before enumeration, which means modifying the `Map` during enumeration will not have the same effect as in AHK. 
+	+ A new `HashMap` class has been added which extends `Map` and does not perform sorting before enumeration.
 * Buffer has an `__Item[]` indexer which can be used to read a byte at a 1-based offset.
 * A new class named `StringBuffer` which can be used for passing string memory to `DllCall()` which will be written to inside of the call.
 	+ There are two methods for creating a `StringBuffer`:


### PR DESCRIPTION
1. `Map` has been modified to sort (and cache) the internal dictionary according to AHK rules: integer < object < string < double, meaning a `Map` with a string key and an integer key will be sorted to [integer, string]. This sorted dictionary is only created for enumeration purposes such as `__Enum` and `ToString()`, and is invalidated if the `Map` is modified. Unfortunately enumeration will still differ between AHK and Keysharp because a copy is enumerated, which means modifying the underlying `Map` will not affect enumeration, but I think this difference is negligible.
2. `HashMap` has been added which does not perform the sorting.
3. Got `MapBench` running which showed no real difference between item read/write with these modifications.
4. Fixed failing hotstring tests.