### PR TITLE
Misc GUI fixes

### DIFF
--- a/Keysharp.Core/Common/ExtensionMethods/GenericExtensions.cs
+++ b/Keysharp.Core/Common/ExtensionMethods/GenericExtensions.cs
@@ -199,30 +199,30 @@
 				{
 					var oldEventInfo = A_EventInfo;
 					var script = Script.TheScript;
-					var (pushed, tv) = script.Threads.BeginThread();
-					if (pushed)//If we've exceeded the number of allowable threads, then just do nothing.
+
+					foreach (var handler in handlers)
 					{
-						tv.eventInfo = oldEventInfo;
-						_ = Flow.TryCatch(() =>
+						if (handler != null)
 						{
-							var script = Script.TheScript;
-							
-							if (inst is Control ctrl && ctrl.FindForm() is Form form)
-								script.HwndLastUsed = form.Handle;
-
-							foreach (var handler in handlers)
+							var (pushed, tv) = script.Threads.BeginThread();
+							if (pushed)//If we've exceeded the number of allowable threads, then just do nothing.
 							{
-								if (handler != null)
+								tv.eventInfo = oldEventInfo;
+								_ = Flow.TryCatch(() =>
 								{
-									result = handler.Call(obj);
+									var script = Script.TheScript;
+							
+									if (inst is Control ctrl && ctrl.FindForm() is Form form)
+										script.HwndLastUsed = form.Handle;
 
-									if (Script.ForceLong(result) != 0L)
-										break;
-								}
+										result = handler.Call(obj);
+									_ = script.Threads.EndThread((pushed, tv));
+								}, true, (pushed, tv));//Pop on exception because EndThread() above won't be called.
+
+								if (Script.ForceLong(result) != 0L)
+									break;
 							}
-
-							_ = script.Threads.EndThread((pushed, tv));
-						}, true, (pushed, tv));//Pop on exception because EndThread() above won't be called.
+						}
 					}
 					script.ExitIfNotPersistent();
 				}

--- a/Keysharp.Core/Common/ExtensionMethods/GenericExtensions.cs
+++ b/Keysharp.Core/Common/ExtensionMethods/GenericExtensions.cs
@@ -216,7 +216,7 @@
 								{
 									result = handler.Call(obj);
 
-									if (result.IsCallbackResultNonEmpty())
+									if (Script.ForceLong(result) != 0L)
 										break;
 								}
 							}

--- a/Keysharp.Core/Common/ExtensionMethods/GenericExtensions.cs
+++ b/Keysharp.Core/Common/ExtensionMethods/GenericExtensions.cs
@@ -199,8 +199,7 @@
 				{
 					var oldEventInfo = A_EventInfo;
 					var script = Script.TheScript;
-					var (pushed, tv) = Script.TheScript.Threads.BeginThread();
-
+					var (pushed, tv) = script.Threads.BeginThread();
 					if (pushed)//If we've exceeded the number of allowable threads, then just do nothing.
 					{
 						tv.eventInfo = oldEventInfo;
@@ -225,6 +224,7 @@
 							_ = script.Threads.EndThread((pushed, tv));
 						}, true, (pushed, tv));//Pop on exception because EndThread() above won't be called.
 					}
+					script.ExitIfNotPersistent();
 				}
 			}
 

--- a/Keysharp.Core/Common/ExtensionMethods/ObjectExtensions.cs
+++ b/Keysharp.Core/Common/ExtensionMethods/ObjectExtensions.cs
@@ -107,7 +107,7 @@
 		/// </summary>
 		/// <param name="result">The callback result to examine.</param>
 		/// <returns>True if non-empty, else false.</returns>
-		public static bool IsCallbackResultNonEmpty(this object result) => result != null&& ((result.ParseLong(false) is long l&& l != 0) || result.ParseBool().IsTrue() || (result is string s&& s != ""));
+		public static bool IsCallbackResultNonEmpty(this object result) => result != null && ((result.ParseLong(false) is long l && l != 0) || (result.ParseDouble(false) is double dl && dl != 0.0) || result.ParseBool().IsTrue() || (result is string s && s != ""));
 
 		/// <summary>
 		/// Returns whether an object is a <see cref="Gui"/>, <see cref="GuiControl"/> or <see cref="Menu"/>.

--- a/Keysharp.Core/Core/Errors.cs
+++ b/Keysharp.Core/Core/Errors.cs
@@ -34,13 +34,14 @@
 					foreach (var handler in script.onErrorHandlers)
 					{
 						var result = handler.Call(err, err.ExcType);
+						var lresult = Script.ForceLong(result);
 
-						if (result.IsCallbackResultNonEmpty())
+						if (lresult != 0L)
 						{
 							err.Handled = true;
 
 							//Calling code will not throw if this is true.
-							if (result.ParseLong(false) == -1L && err.ExcType == Keyword_Return)
+							if (lresult == -1L && err.ExcType == Keyword_Return)
 								exitThread = false;
 
 							break;

--- a/Keysharp.Core/Core/Flow.cs
+++ b/Keysharp.Core/Core/Flow.cs
@@ -583,7 +583,7 @@ namespace Keysharp.Core
 			var result = script.onExitHandlers.InvokeEventHandlers(A_ExitReason, exitCode);
 
 			//If it wasn't a critical shutdown and any exit handlers returned a non empty value, abort the exit.
-			if (exitReason >= ExitReasons.None && result.IsCallbackResultNonEmpty())
+			if (exitReason >= ExitReasons.None && Script.ForceLong(result) != 0L)
 			{
 				A_ExitReason = "";
 				fd.allowInterruption = allowInterruption_prev;

--- a/Keysharp.Core/Core/Gui/Controls.cs
+++ b/Keysharp.Core/Core/Gui/Controls.cs
@@ -862,7 +862,7 @@ namespace Keysharp.Core
 							rect.Height -= inset * 2;
 							bx = rect.Width + inset;
 							by = inset;
-							bw = Width - rect.Width - inset;
+							bw = Width - rect.Width - inset * 2;
 							bh = rect.Height;
 						}
 

--- a/Keysharp.Core/Core/Gui/Gui.cs
+++ b/Keysharp.Core/Core/Gui/Gui.cs
@@ -1052,12 +1052,14 @@
 					if (opts.vertical)
 						opts.addstyle |= 0x04;
 
-					var prg = new KeysharpProgressBar(opts.bgcolor.HasValue || opts.c != System.Windows.Forms.Control.DefaultForeColor,
+					bool smooth = opts.smooth.IsTrue();
+
+					var prg = new KeysharpProgressBar(smooth || opts.bgcolor.HasValue || opts.c != System.Windows.Forms.Control.DefaultForeColor,
 													  opts.addstyle, opts.addexstyle, opts.remstyle, opts.remexstyle)
 					{
 						Font = Conversions.ConvertFont(form.Font)
 					};
-					prg.Style = opts.smooth.IsTrue() ? ProgressBarStyle.Continuous : ProgressBarStyle.Blocks;
+					prg.Style = smooth ? ProgressBarStyle.Continuous : ProgressBarStyle.Blocks;
 
 					if (opts.nudlow.HasValue)
 						prg.Minimum = opts.nudlow.Value;
@@ -1074,7 +1076,7 @@
 #if WINDOWS
 
 					if (opts.vertical && opts.width == int.MinValue && opts.height == int.MinValue)
-						(prg.Height, prg.Width) = (prg.Width, prg.Height);
+							(prg.Height, prg.Width) = (prg.Width, prg.Height);
 
 #endif
 					ctrl = prg;
@@ -1320,11 +1322,11 @@
 						r = 3;
 					else if (ctrl is KeysharpListView || ctrl is KeysharpTreeView || (ctrl is KeysharpProgressBar kpb2 && ((kpb2.AddStyle & 0x04) == 0x04)))
 						r = 5;
-					else if (ctrl is KeysharpGroupBox || ctrl is KeysharpProgressBar)
+					else if (ctrl is KeysharpGroupBox)
 						r = 2;
 					else if (ctrl is KeysharpTextBox tb)
 						r = tb.Multiline ? 3 : 1;
-					else if (ctrl is KeysharpDateTimePicker || ctrl is HotkeyBox)
+					else if (ctrl is KeysharpDateTimePicker || ctrl is HotkeyBox || ctrl is KeysharpProgressBar)
 						r = 1;
 					else if (ctrl is TabPage || ctrl is KeysharpTabControl)
 						r = 10;

--- a/Keysharp.Core/Core/Gui/GuiControl.cs
+++ b/Keysharp.Core/Core/Gui/GuiControl.cs
@@ -2055,7 +2055,7 @@
 						if (notifyHandlers.TryGetValue((int)nmhdr.code, out var handler))
 						{
 							var ret = handler?.InvokeEventHandlers(this, m.LParam.ToInt64());
-							m.Result = ret.IsCallbackResultNonEmpty() ? 1 : 0;
+							m.Result = (nint)Script.ForceLong(ret);
 							return true;
 						}
 					}
@@ -2070,7 +2070,7 @@
 						if (commandHandlers.TryGetValue(val, out var handler))
 						{
 							var ret = handler?.InvokeEventHandlers(this);
-							m.Result = ret.IsCallbackResultNonEmpty() ? 1 : 0;
+							m.Result = (nint)Script.ForceLong(ret);
 							return true;
 						}
 					}

--- a/Keysharp.Core/Core/Gui/GuiHelper.cs
+++ b/Keysharp.Core/Core/Gui/GuiHelper.cs
@@ -107,6 +107,10 @@
 					control.BackColor = requestedColor;
 					m.Result = new nint(colorValue);
 					return true;
+
+				case WindowsAPI.STM_SETIMAGE:
+					control.BackgroundImage = Image.FromHbitmap(m.LParam);
+					return true;
 			}
 
 #endif

--- a/Keysharp.Core/Core/Gui/GuiHelper.cs
+++ b/Keysharp.Core/Core/Gui/GuiHelper.cs
@@ -88,7 +88,7 @@
 				{
 					var ret = ctrl.InvokeMessageHandlers(ref m);
 
-					if (ret.IsCallbackResultNonEmpty())
+					if (Script.ForceLong(ret) != 0L)
 						return true;
 				}
 			}

--- a/Keysharp.Core/Core/Gui/KeysharpForm.cs
+++ b/Keysharp.Core/Core/Gui/KeysharpForm.cs
@@ -121,7 +121,7 @@
 					var result = closedHandlers?.InvokeEventHandlers(g);
 					e.Cancel = true;
 
-					if (result.IsCallbackResultNonEmpty())
+					if (result.IsCallbackResultNonEmpty() && (result is long || result is bool))
 						return;
 
 					Hide();

--- a/Keysharp.Core/Core/Gui/KeysharpForm.cs
+++ b/Keysharp.Core/Core/Gui/KeysharpForm.cs
@@ -121,7 +121,7 @@
 					var result = closedHandlers?.InvokeEventHandlers(g);
 					e.Cancel = true;
 
-					if (result.IsCallbackResultNonEmpty() && (result is long || result is bool))
+					if (Script.ForceLong(result) != 0L)
 						return;
 
 					Hide();

--- a/Keysharp.Core/Windows/WindowsAPI.cs
+++ b/Keysharp.Core/Windows/WindowsAPI.cs
@@ -801,6 +801,8 @@ namespace Keysharp.Core.Windows
 
 		internal const int PBM_SETBKCOLOR = 0x2001;
 
+		internal const int STM_SETIMAGE = 0x172;
+
 		internal const int CBN_ERRSPACE = -1;
 		internal const int CBN_SELCHANGE = 1;
 		internal const int CBN_DBLCLK = 2;


### PR DESCRIPTION
1. Call `ExitIfNotPersistent` after calling GUI event handlers. Otherwise if an event handler is running and the user closes the GUI, the script won't exit after the event handler completes.
2. ProgressBar default height appears to be r1, not r2
3. Use custom painting for ProgressBar if Smooth option is used, because apparently AHK does that
4. `Gui.OnEvent("Close", callback)` should only prevent GUI close if a non-zero numeric value is returned (as per the documentation).
5. Add support for `STM_SETIMAGE` message.

Notes:
1. In Windows 10 my ProgressBar doesn't seem to use smooth or block styles, it's always smooth. The only difference seems to be whether AHK paints it "manually" or not:
```
g := Gui()
pg := g.AddProgress("w200 r2", 50)
g.Show()
```
<img width="332" height="104" alt="image" src="https://github.com/user-attachments/assets/3075c891-e0f0-4394-aae2-6fd7729f74c6" />
and with the "smooth" option:
<img width="332" height="104" alt="image" src="https://github.com/user-attachments/assets/5a878d0e-788c-4c9d-a26f-1ee4eb1fc958" />
2. Why aren't we calling `ExitIfNotPersistent` in `EndThread` instead? 
3. Currently `InvokeEventHandlers` in GenericExtensions.cs runs all handlers in the same pseudo-thread, but we should probably use fresh threads for each handler? Haven't verified how AHK handles it, but I'd guess it creates new threads.