### PR TITLE
Multiple miscallaneous fixes

### DIFF
--- a/Keysharp.Core/Common/Invoke/ArgumentHelper.cs
+++ b/Keysharp.Core/Common/Invoke/ArgumentHelper.cs
@@ -165,8 +165,11 @@ namespace Keysharp.Core.Common.Invoke
 						goto TypeDetermined;
 					}
 
-					if (p is string s)
+					if (p is IPointable ip)
+						args[n] = ip.Ptr;
+					else if (p is not Any)
 					{
+						string s = ForceString(p);
 						nint bstr = Marshal.StringToBSTR(s);
 						_bstrs.Add(bstr);
 						args[n] = bstr;
@@ -189,13 +192,17 @@ namespace Keysharp.Core.Common.Invoke
 						goto TypeDetermined;
 					}
 
-					if (p is string s)
+					if (p is IPointable ip)
+						args[n] = ip.Ptr;
+					else if (p is not Any)
 					{
+						p = ForceString(p);
 						SetupPointerArg();
 					}
 					else
 					{
-						ConvertPtr();
+						_ = Errors.TypeErrorOccurred(tag, typeof(string));
+						return;
 					}
 
 					continue;
@@ -213,8 +220,11 @@ namespace Keysharp.Core.Common.Invoke
 						goto TypeDetermined;
 					}
 
-					if (p is string s)
+					if (p is IPointable ip)
+						args[n] = ip.Ptr;
+					else if (p is not Any)
 					{
+						string s = ForceString(p);
 						byte[] ascii = Encoding.ASCII.GetBytes(s);
 						var gch = GCHandle.Alloc(ascii, GCHandleType.Pinned);
 						gcHandles.Add(gch);
@@ -445,6 +455,8 @@ namespace Keysharp.Core.Common.Invoke
 					args[n] = lptr;
 				else if (p is string s)
 					args[n] = s.Al();
+				else if (p is IPointable ip)
+					args[n] = ip.Ptr;
 				else if (p is Array arrPtr)
 				{
 					SetupPointerArg();

--- a/Keysharp.Core/Common/Invoke/ArgumentHelper.cs
+++ b/Keysharp.Core/Common/Invoke/ArgumentHelper.cs
@@ -1,8 +1,16 @@
 ﻿#if WINDOWS
 namespace Keysharp.Core.Common.Invoke
 {
-	internal class ArgumentHelper
+	internal class ComArgumentHelper : ArgumentHelper
 	{
+		internal ComArgumentHelper(object[] parameters) : base(parameters)
+		{
+			isCom = true;
+		}
+	}
+	internal class ArgumentHelper : IDisposable
+	{
+		protected bool isCom = false;
 		protected bool cdecl = false;
 		protected bool hresult = false;
 		protected List<GCHandle> gcHandles = [];
@@ -201,7 +209,7 @@ namespace Keysharp.Core.Common.Invoke
 				{
 					if (parseType)
 					{
-						type = isReturn ? typeof(string) : typeof(nint);
+						type = isReturn ? typeof(char[]) : typeof(nint);
 						goto TypeDetermined;
 					}
 
@@ -452,6 +460,49 @@ namespace Keysharp.Core.Common.Invoke
 					SetupPointerArg();
 				}
 			}
+		}
+
+		internal unsafe object ConvertReturnValue(object value)
+		{
+			// If the return type was omitted then it should be treated as HRESULT
+			// and if that is a negative value then throw an OSError
+			if (HRESULT || (isCom && !HasReturn))
+			{
+				long hrLong = (long)value;                // unbox the raw long
+				int hr32 = unchecked((int)hrLong);   // keep only the low 32 bits
+				return Errors.OSErrorOccurredForHR(hr32);
+			}
+
+			//Special conversion for the return value.
+			else if (ReturnType == typeof(int))
+			{
+				long l = (long)value;
+				int ii = *(int*)&l;
+				value = ii;
+			}
+			else if (ReturnType == typeof(float))
+			{
+				if (value is not double) return _ = Errors.TypeErrorOccurred(value, typeof(double));
+
+				double d = (double)value;
+				float f = *(float*)&d;
+				return f;
+			}
+			else if (ReturnType == typeof(char[]))
+			{
+				nint ptr = (nint)(long)value;
+				var str = Marshal.PtrToStringAnsi(ptr);
+				Marshal.FreeHGlobal(ptr);
+				return str;
+			}
+			else if (ReturnType == typeof(string))
+			{
+				var str = Marshal.PtrToStringUni((nint)(long)value);
+				_ = Objects.ObjFree(value);//If this string came from us, it will be freed, else no action.
+				return str;
+			}
+
+			return value;
 		}
 	}
 }

--- a/Keysharp.Core/Common/Window/MainWindow.cs
+++ b/Keysharp.Core/Common/Window/MainWindow.cs
@@ -122,7 +122,6 @@
 
 		protected override void WndProc(ref Message m)
 		{
-			var handled = false;
 #if WINDOWS
 
 			switch (m.Msg)
@@ -130,24 +129,10 @@
 				case WindowsAPI.WM_CLIPBOARDUPDATE:
 					if (clipSuccess)
 						ClipboardUpdate?.Invoke(null);
-
-					handled = true;
 					break;
-
-				case WindowsAPI.WM_COPYDATA:
-				{
-					if (Script.TheScript.GuiData.onMessageHandlers.TryGetValue(m.Msg, out var msgMonitor))//Needs to be handled here instead of MessageFilter because that one doesn't seem to intercept it.
-					{
-						var copyStruct = (WindowsAPI.COPYDATASTRUCT)m.GetLParam(typeof(WindowsAPI.COPYDATASTRUCT));
-						_ = msgMonitor.funcs.InvokeEventHandlers(m.WParam.ToInt64(), copyStruct.lpData, m.Msg, m.HWnd.ToInt64());
-						handled = true;
-					}
-				}
-				break;
 
 				case WindowsAPI.WM_ENDSESSION:
 					_ = Flow.ExitAppInternal((m.Msg & WindowsAPI.ENDSESSION_LOGOFF) != 0 ? Flow.ExitReasons.LogOff : Flow.ExitReasons.Shutdown, null, false);
-					handled = true;
 					break;
 
 				case WindowsAPI.WM_HOTKEY://We will need to find a cross platform way to do this. At the moment, hotkeys appear to be a built in feature in Windows.//TODO
@@ -158,15 +143,11 @@
 						wParam = m.WParam,
 						lParam = m.LParam,
 					});
-					handled = true;
 					break;
 			}
 
 #endif
 			base.WndProc(ref m);
-
-			if (handled)
-				m.Result = new nint(1);
 		}
 
 		private void aboutToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Keysharp.Core/Common/Window/MessageFilter.cs
+++ b/Keysharp.Core/Common/Window/MessageFilter.cs
@@ -3,6 +3,7 @@
 	internal class MessageFilter : IMessageFilter
 	{
 		Script script;
+		internal Message lastMsg;
 		internal MessageFilter(Script associatedScript)
 		{
 			script = associatedScript;
@@ -12,11 +13,6 @@
 		{
 			if (script.GuiData.onMessageHandlers.TryGetValue(m.Msg, out var monitor))
 			{
-				if (isPreFilter && !monitor.isPrefiltered)
-					monitor.isPrefiltered = true;
-				else if (!isPreFilter && monitor.isPrefiltered)
-					return false;
-
 				var tv = script.Threads.CurrentThread;
 
 				if (!script.Threads.AnyThreadsAvailable() || tv.priority > 0)
@@ -50,6 +46,16 @@
 			return false;
 		}
 
-		public bool PreFilterMessage(ref Message m) => CallEventHandlers(ref m);
+		public bool PreFilterMessage(ref Message m)
+		{
+			if (m.HWnd != 0)
+			{
+				var ctl = Control.FromHandle(m.HWnd);
+				if (ctl == null || !(ctl.FindForm() is KeysharpForm))
+					return false;
+			}
+			lastMsg = m;
+			return CallEventHandlers(ref m);
+		}
 	}
 }

--- a/Keysharp.Core/Common/Window/MessageFilter.cs
+++ b/Keysharp.Core/Common/Window/MessageFilter.cs
@@ -2,12 +2,21 @@
 {
 	internal class MessageFilter : IMessageFilter
 	{
-		public bool PreFilterMessage(ref Message m)
+		Script script;
+		internal MessageFilter(Script associatedScript)
 		{
-			var script = Script.TheScript;
-			
+			script = associatedScript;
+		}
+
+		internal bool CallEventHandlers(ref Message m, bool isPreFilter = true)
+		{
 			if (script.GuiData.onMessageHandlers.TryGetValue(m.Msg, out var monitor))
 			{
+				if (isPreFilter && !monitor.isPrefiltered)
+					monitor.isPrefiltered = true;
+				else if (!isPreFilter && monitor.isPrefiltered)
+					return false;
+
 				var tv = script.Threads.CurrentThread;
 
 				if (!script.Threads.AnyThreadsAvailable() || tv.priority > 0)
@@ -40,5 +49,7 @@
 
 			return false;
 		}
+
+		public bool PreFilterMessage(ref Message m) => CallEventHandlers(ref m);
 	}
 }

--- a/Keysharp.Core/Common/Window/MsgMonitor.cs
+++ b/Keysharp.Core/Common/Window/MsgMonitor.cs
@@ -5,5 +5,6 @@
 		internal int instanceCount;
 		internal int maxInstances = 1;
 		internal List<IFuncObj> funcs = [];
+		internal bool isPrefiltered = false;
 	}
 }

--- a/Keysharp.Core/Core/Accessors.cs
+++ b/Keysharp.Core/Core/Accessors.cs
@@ -823,7 +823,7 @@
 		/// <summary>
 		/// The result from the Windows GetLastError() function.
 		/// </summary>
-		public static long A_LastError => Marshal.GetLastWin32Error();//This apparently works on linux too.
+		public static long A_LastError => Marshal.GetLastSystemError();//This apparently works on linux too.
 
 		/// <summary>
 		/// ListLines is never true.

--- a/Keysharp.Core/Core/Accessors.cs
+++ b/Keysharp.Core/Core/Accessors.cs
@@ -823,7 +823,7 @@
 		/// <summary>
 		/// The result from the Windows GetLastError() function.
 		/// </summary>
-		public static long A_LastError => Marshal.GetLastSystemError();//This apparently works on linux too.
+		public static long A_LastError => Marshal.GetLastPInvokeError();//This apparently works on linux too.
 
 		/// <summary>
 		/// ListLines is never true.

--- a/Keysharp.Core/Core/COM/Com.cs
+++ b/Keysharp.Core/Core/COM/Com.cs
@@ -421,41 +421,12 @@ namespace Keysharp.Core.COM
 				return Errors.ValueErrorOccurred($"The passed in object was not a ComObject or a raw COM interface.");
 
 			var pVtbl = Marshal.ReadIntPtr(pUnk);
-			var helper = new ArgumentHelper(parameters);
+			var helper = new ComArgumentHelper(parameters);
 			var value = NativeInvoke(pUnk.ToInt64(), Marshal.ReadIntPtr(nint.Add(pVtbl, idx * sizeof(nint))), helper.args, helper.floatingTypeMask);
 			Dll.FixParamTypesAndCopyBack(parameters, helper);
+			var result = helper.ConvertReturnValue(value);
 			helper.Dispose();
-
-			// If the return type was omitted then it should be treated as HRESULT
-			// and if that is a negative value then throw an OSError
-			if (helper.HRESULT || !helper.HasReturn)
-			{
-				long hrLong = (long)value;                // unbox the raw long
-				int hr32 = unchecked((int)hrLong);   // keep only the low 32 bits
-				return Errors.OSErrorOccurredForHR(hr32);
-			}
-
-			//Special conversion for the return value.
-			if (helper.ReturnType == typeof(int))
-			{
-				long l = (long)value;
-				int ii = *(int*)&l;
-				value = ii;
-			}
-			else if (helper.ReturnType == typeof(float))
-			{
-				double d = (double)value;
-				float f = *(float*)&d;
-				return f;
-			}
-			else if (helper.ReturnType == typeof(string))
-			{
-				var str = Marshal.PtrToStringUni((nint)(long)value);
-				_ = Objects.ObjFree(value);//If this string came from us, it will be freed, else no action.
-				return str;
-			}
-
-			return value;
+			return result;
 		}
 
 		internal static object NativeInvoke(long objPtr, nint vtbl, long[] args, ulong mask)

--- a/Keysharp.Core/Core/Dll.cs
+++ b/Keysharp.Core/Core/Dll.cs
@@ -252,39 +252,9 @@ namespace Keysharp.Core
 				var helper = new ArgumentHelper(parameters);
 				var value = NativeInvoke(address, helper.args, helper.floatingTypeMask);
 				FixParamTypesAndCopyBack(parameters, helper);
+				var result = helper.ConvertReturnValue(value);
 				helper.Dispose();
-
-				// If the return type was HRESULT and it is a negative value then throw an OSError
-				if (helper.HRESULT)
-				{
-					long hrLong = (long)value;                // unbox the raw long
-					int hr32 = unchecked((int)hrLong);   // keep only the low 32 bits
-
-					return Errors.OSErrorOccurredForHR(hr32);
-				}
-				//Special conversion for the return value.
-				else if (helper.ReturnType == typeof(int))
-				{
-					long l = (long)value;
-					int ii = *(int*)&l;
-					value = ii;
-				}
-				else if (helper.ReturnType == typeof(float))
-				{
-					if (value is not double) return _ = Errors.TypeErrorOccurred(value, typeof(double));
-
-					double d = (double)value;
-					float f = *(float*)&d;
-					return f;
-				}
-				else if (helper.ReturnType == typeof(string))
-				{
-					var str = Marshal.PtrToStringUni((nint)(long)value);
-					_ = Objects.ObjFree(value);//If this string came from us, it will be freed, else no action.
-					return str;
-				}
-
-				return value;
+				return result;
 			}
 			catch (KeysharpException)
 			{

--- a/Keysharp.Core/Core/Dll.cs
+++ b/Keysharp.Core/Core/Dll.cs
@@ -361,6 +361,8 @@ namespace Keysharp.Core
 			else
 				result = ((Func<nint, long[], long>)del)(fnPtr, args);
 
+			Marshal.SetLastPInvokeError(Marshal.GetLastSystemError());
+
 			if (shim != 0)
 				script.ExecutableMemoryPoolManager.Return(shim);
 

--- a/Keysharp.Core/Core/Gui/KeysharpForm.cs
+++ b/Keysharp.Core/Core/Gui/KeysharpForm.cs
@@ -28,6 +28,12 @@
 			}
 		}
 
+		protected override void WndProc(ref Message m)
+		{
+			if (!TheScript.msgFilter.CallEventHandlers(ref m, false))
+				base.WndProc(ref m);
+		}
+
 		[Browsable(false)]
 		protected override bool ShowWithoutActivation => showWithoutActivation;
 
@@ -231,5 +237,7 @@
 			else
 				ClearThis();
 		}
+
+
 	}
 }

--- a/Keysharp.Core/Core/Gui/KeysharpForm.cs
+++ b/Keysharp.Core/Core/Gui/KeysharpForm.cs
@@ -30,8 +30,10 @@
 
 		protected override void WndProc(ref Message m)
 		{
-			if (!TheScript.msgFilter.CallEventHandlers(ref m, false))
-				base.WndProc(ref m);
+			var msgFilter = TheScript.msgFilter;
+			if (msgFilter.lastMsg != m && msgFilter.CallEventHandlers(ref m, false))
+				return;
+			base.WndProc(ref m);
 		}
 
 		[Browsable(false)]

--- a/Keysharp.Core/Core/Gui/KeysharpForm.cs
+++ b/Keysharp.Core/Core/Gui/KeysharpForm.cs
@@ -30,9 +30,26 @@
 
 		protected override void WndProc(ref Message m)
 		{
+			// In Windows queued messages (eg sent with PostMessage) arrive in the message queue and
+			// are read with GetMessage, then when DispatchMessage is called (after TranslateMessage)
+			// WndProc is called with the translated message. Non-queued message (eg sent with SendMessage)
+			// arrive directly in WndProc.
+			// In C# MessageFilter processes the message after GetMessage has received it, and if let through
+			// then TranslateMessage and DispatchMessage are called, which then in turn call WndProc.
+			// The problem is how to determine whether a message has already been processed in MessageFilter to
+			// avoid double-handing. AutoHotkey uses a global variable before DispatchMessage and nulls it
+			// afterwards, and we use a similar approach here. MessageFilter stashes the handled
+			// message (only messages which target a KeysharpForm) and then we compare here for
+			// equality. A simple boolean like isHandled wouldn't be enough because for example
+			// WM_KEYDOWN will get translated to WM_CHAR and the user may want to capture that as well.
+			// Additionally if any messages get lost for some reason or another message arrives here
+			// before the MessageFilter processed message has had time to arrive then we'd confuse the two.
 			var msgFilter = TheScript.msgFilter;
-			if (msgFilter.lastMsg != m && msgFilter.CallEventHandlers(ref m, false))
+			if (msgFilter.handledMsg == m)
+				msgFilter.handledMsg = null;
+			else if (msgFilter.CallEventHandlers(ref m))
 				return;
+
 			base.WndProc(ref m);
 		}
 

--- a/Keysharp.Core/Core/Strings.cs
+++ b/Keysharp.Core/Core/Strings.cs
@@ -1033,25 +1033,45 @@
 				{
 					return encoding == Encoding.Unicode ? Marshal.PtrToStringUni(ptr) : Marshal.PtrToStringAnsi(ptr);
 				}
-				else if (len < 0)//Length is negative, copy exactly the absolute value of len, regardless of 0s. Clamp to buf size of buf.
+				else
 				{
+					//If length is negative, copy exactly the absolute value of len, regardless of 0s. Clamp to buf size of buf.
+					//If length is positive, copy as long as length is not reached and value is not 0.
 					var raw = (byte*)ptr.ToPointer();
-					var abs = Math.Abs(len);
+					var abs = (int)Math.Abs(len);
 
-					if (encoding != Encoding.ASCII)//Sort of crude, UTF-8 can require up to 4 bytes per char.
-						abs *= 2;
+					abs = encoding.GetMaxByteCount(abs);
+					int maxBytes = buf != null ? (int)Math.Min((long)buf.Size, abs) : abs;
 
-					var finalLen = (int)(buf != null ? Math.Min((long)buf.Size, abs) : abs);
-					var bytes = new byte[finalLen];
+					Span<byte> span = new Span<byte>(raw, maxBytes);
 
-					for (var i = 0; i < finalLen; i++)
-						bytes[i] = raw[i];
+					if (len > 0)
+					{
+						int terminatorIndex;
+						if (encoding is UnicodeEncoding) // UTF-16, 2-byte code‐units
+						{
+							// reinterpret as chars, look for '\0', then convert back to byte‐index
+							var charSpan = MemoryMarshal.Cast<byte, char>(span);
+							int ci = charSpan.IndexOf('\0');
+							terminatorIndex = (ci >= 0) ? ci * sizeof(char) : -1;
+						}
+						else if (encoding is UTF32Encoding) // UTF-32, 4-byte code‐units
+						{
+							// reinterpret as ints, look for 0, then convert back to byte‐index
+							var intSpan = MemoryMarshal.Cast<byte, int>(span);
+							int ii = intSpan.IndexOf(0);
+							terminatorIndex = (ii >= 0) ? ii * sizeof(int) : -1;
+						}
+						else // all single-byte encodings (ANSI, UTF-8, etc.)
+						{
+							terminatorIndex = span.IndexOf((byte)0);
+						}
 
-					return encoding.GetString(bytes);
-				}
-				else//Positive length was passed, copy as long as length is not reached and value is not 0.
-				{
-					return encoding == Encoding.Unicode ? Marshal.PtrToStringUni(ptr, (int)len) : Marshal.PtrToStringAnsi(ptr, (int)len);
+						if (terminatorIndex != -1)
+							span = span.Slice(0, terminatorIndex);
+					}
+
+					return encoding.GetString(span);
 				}
 			}
 		}

--- a/Keysharp.Core/Core/Strings.cs
+++ b/Keysharp.Core/Core/Strings.cs
@@ -1031,48 +1031,49 @@
 			{
 				if (len == long.MinValue)//No length specified, only copy up to the first 0.
 				{
-					return encoding == Encoding.Unicode ? Marshal.PtrToStringUni(ptr) : Marshal.PtrToStringAnsi(ptr);
+					if (buf != null)
+						len = (long)buf.Size;
+					else
+						return encoding == Encoding.Unicode ? Marshal.PtrToStringUni(ptr) : Marshal.PtrToStringAnsi(ptr);
 				}
-				else
+
+				//If length is negative, copy exactly the absolute value of len, regardless of 0s. Clamp to buf size of buf.
+				//If length is positive, copy as long as length is not reached and value is not 0.
+				var raw = (byte*)ptr.ToPointer();
+				var abs = (int)Math.Abs(len);
+
+				abs = encoding.GetMaxByteCount(abs);
+				int maxBytes = buf != null ? (int)Math.Min((long)buf.Size, abs) : abs;
+
+				Span<byte> span = new Span<byte>(raw, maxBytes);
+
+				if (len > 0)
 				{
-					//If length is negative, copy exactly the absolute value of len, regardless of 0s. Clamp to buf size of buf.
-					//If length is positive, copy as long as length is not reached and value is not 0.
-					var raw = (byte*)ptr.ToPointer();
-					var abs = (int)Math.Abs(len);
-
-					abs = encoding.GetMaxByteCount(abs);
-					int maxBytes = buf != null ? (int)Math.Min((long)buf.Size, abs) : abs;
-
-					Span<byte> span = new Span<byte>(raw, maxBytes);
-
-					if (len > 0)
+					int terminatorIndex;
+					if (encoding is UnicodeEncoding) // UTF-16, 2-byte code‐units
 					{
-						int terminatorIndex;
-						if (encoding is UnicodeEncoding) // UTF-16, 2-byte code‐units
-						{
-							// reinterpret as chars, look for '\0', then convert back to byte‐index
-							var charSpan = MemoryMarshal.Cast<byte, char>(span);
-							int ci = charSpan.IndexOf('\0');
-							terminatorIndex = (ci >= 0) ? ci * sizeof(char) : -1;
-						}
-						else if (encoding is UTF32Encoding) // UTF-32, 4-byte code‐units
-						{
-							// reinterpret as ints, look for 0, then convert back to byte‐index
-							var intSpan = MemoryMarshal.Cast<byte, int>(span);
-							int ii = intSpan.IndexOf(0);
-							terminatorIndex = (ii >= 0) ? ii * sizeof(int) : -1;
-						}
-						else // all single-byte encodings (ANSI, UTF-8, etc.)
-						{
-							terminatorIndex = span.IndexOf((byte)0);
-						}
-
-						if (terminatorIndex != -1)
-							span = span.Slice(0, terminatorIndex);
+						// reinterpret as chars, look for '\0', then convert back to byte‐index
+						var charSpan = MemoryMarshal.Cast<byte, char>(span);
+						int ci = charSpan.IndexOf('\0');
+						terminatorIndex = (ci >= 0) ? ci * sizeof(char) : -1;
+					}
+					else if (encoding is UTF32Encoding) // UTF-32, 4-byte code‐units
+					{
+						// reinterpret as ints, look for 0, then convert back to byte‐index
+						var intSpan = MemoryMarshal.Cast<byte, int>(span);
+						int ii = intSpan.IndexOf(0);
+						terminatorIndex = (ii >= 0) ? ii * sizeof(int) : -1;
+					}
+					else // all single-byte encodings (ANSI, UTF-8, etc.)
+					{
+						terminatorIndex = span.IndexOf((byte)0);
 					}
 
-					return encoding.GetString(span);
+					if (terminatorIndex != -1)
+						span = span.Slice(0, terminatorIndex);
 				}
+
+				return encoding.GetString(span);
 			}
 		}
 

--- a/Keysharp.Core/Scripting/Parser/Parser.cs
+++ b/Keysharp.Core/Scripting/Parser/Parser.cs
@@ -1239,15 +1239,16 @@ namespace Keysharp.Scripting
 			_ = initial.Add(new CodeSnippetExpression($"{ScriptObject.Name}.SetName(name)"));
 			_ = initial.Add(new CodeAssignStatement(HotstringManagerObjectSnippet, new CodeSnippetExpression($"{ScriptObjectName}.HotstringManager")));
 			_ = initial.Add(condInst);
-			_ = initial.Add(new CodeAssignStatement(ScriptObjectSnippet, new CodeObjectCreateExpression(typeof(Keysharp.Scripting.Script))));
 
-			foreach (var (p, s) in preReader.PreloadedDlls)//Add after Script.Init() call above, because the statements will be added in reverse order.
+			foreach (var (p, s) in preReader.PreloadedDlls)//Add before Script.Init() call below, because the statements will be added in reverse order.
 			{
-				var cmie = new CodeMethodInvokeExpression(new CodeTypeReferenceExpression("Keysharp.Scripting.Script.Variables"), "AddPreLoadedDll");
+				var cmie = new CodeMethodInvokeExpression(ScriptObjectSnippet, "LoadDll");
 				_ = cmie.Parameters.Add(new CodePrimitiveExpression(p));
 				_ = cmie.Parameters.Add(new CodePrimitiveExpression(s));
 				initial.Add(new CodeExpressionStatement(cmie));
 			}
+
+			_ = initial.Add(new CodeAssignStatement(ScriptObjectSnippet, new CodeObjectCreateExpression(typeof(Keysharp.Scripting.Script))));
 
 			var namevar = new CodeVariableDeclarationStatement("System.String", "name", new CodePrimitiveExpression(name));
 			_ = initial.Add(namevar);

--- a/Keysharp.Core/Scripting/Script/Script.cs
+++ b/Keysharp.Core/Scripting/Script/Script.cs
@@ -218,8 +218,6 @@ namespace Keysharp.Scripting
 			if (path != "testhost.exe" && path != "testhost.dll" && !A_IsCompiled)
 				_ = Dir.SetWorkingDir(A_ScriptDir);
 
-			//Preload dlls requested with #DllLoad
-			LoadDlls();
 			msgFilter = new MessageFilter(this);
 			Application.AddMessageFilter(msgFilter);
 			_ = InitHook();//Why is this always being initialized even when there are no hooks? This is very inefficient.//TODO
@@ -243,53 +241,55 @@ namespace Keysharp.Scripting
 			loopShouldDoEvents = true;
 		}
 
-		private void LoadDlls()
+		/// <summary>
+		/// Will be a generated call within Main which calls into this class to add DLLs.
+		/// </summary>
+		/// <param name="p"></param>
+		/// <param name="s"></param>
+		public void LoadDll(string dll, bool throwOnFailure = true)
 		{
-			foreach (var dll in Vars.preloadedDlls)
+			if (dll.Length == 0)
 			{
-				if (dll.Item1.Length == 0)
-				{
-					if (!mgr.SetDllDirectory(null))//An empty #DllLoad restores the default search order.
-						if (!dll.Item2)
-						{
-							_ = Errors.ErrorOccurred("PlatformProvider.Manager.SetDllDirectory(null) failed.", null, Keyword_ExitApp);
-							return;
-						}
-				}
-				else if (Directory.Exists(dll.Item1))
-				{
-					if (!mgr.SetDllDirectory(dll.Item1))
-						if (!dll.Item2)
-						{
-							_ = Errors.ErrorOccurred($"PlatformProvider.Manager.SetDllDirectory({dll.Item1}) failed.", null, Keyword_ExitApp);
-							return;
-						}
-				}
-				else
-				{
-					var dllname = dll.Item1;
-#if WINDOWS
-
-					if (!dllname.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-						dllname += ".dll";
-
-#endif
-					var hmodule = mgr.LoadLibrary(dllname);
-
-					if (hmodule != 0)
+				if (!mgr.SetDllDirectory(null))//An empty #DllLoad restores the default search order.
+					if (throwOnFailure)
 					{
-#if WINDOWS
-						// "Pin" the dll so that the script cannot unload it with FreeLibrary.
-						// This is done to avoid undefined behavior when DllCall optimizations
-						// resolves a proc address in a dll loaded by this directive.
-						_ = WindowsAPI.GetModuleHandleEx(WindowsAPI.GET_MODULE_HANDLE_EX_FLAG_PIN, dllname, out hmodule);  // MSDN regarding hmodule: "If the function fails, this parameter is NULL."
-#endif
-					}
-					else if (!dll.Item2)
-					{
-						_ = Errors.ErrorOccurred($"Failed to load DLL {dllname}.", null, Keyword_ExitApp);
+						_ = Errors.ErrorOccurred("PlatformProvider.Manager.SetDllDirectory(null) failed.", null, Keyword_ExitApp);
 						return;
 					}
+			}
+			else if (Directory.Exists(dll))
+			{
+				if (!mgr.SetDllDirectory(dll))
+					if (throwOnFailure)
+					{
+						_ = Errors.ErrorOccurred($"PlatformProvider.Manager.SetDllDirectory({dll}) failed.", null, Keyword_ExitApp);
+						return;
+					}
+			}
+			else
+			{
+				var dllname = dll;
+#if WINDOWS
+
+				if (!dllname.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+					dllname += ".dll";
+
+#endif
+				var hmodule = mgr.LoadLibrary(dllname);
+
+				if (hmodule != 0)
+				{
+#if WINDOWS
+					// "Pin" the dll so that the script cannot unload it with FreeLibrary.
+					// This is done to avoid undefined behavior when DllCall optimizations
+					// resolves a proc address in a dll loaded by this directive.
+					_ = WindowsAPI.GetModuleHandleEx(WindowsAPI.GET_MODULE_HANDLE_EX_FLAG_PIN, dllname, out hmodule);  // MSDN regarding hmodule: "If the function fails, this parameter is NULL."
+#endif
+				}
+				else if (throwOnFailure)
+				{
+					_ = Errors.ErrorOccurred($"Failed to load DLL {dllname}.", null, Keyword_ExitApp);
+					return;
 				}
 			}
 		}

--- a/Keysharp.Core/Scripting/Script/Script.cs
+++ b/Keysharp.Core/Scripting/Script/Script.cs
@@ -23,6 +23,7 @@ namespace Keysharp.Scripting
 #endif
 		public const char dotNetMajorVersion = '9';
 		internal System.Timers.Timer tickTimer = new System.Timers.Timer(SLEEP_INTERVAL * 4);
+		internal MessageFilter msgFilter;
 		internal volatile bool loopShouldDoEvents = false;
 		internal volatile bool hasExited = false;
 		public bool ForceKeybdHook;
@@ -219,7 +220,8 @@ namespace Keysharp.Scripting
 
 			//Preload dlls requested with #DllLoad
 			LoadDlls();
-			Application.AddMessageFilter(new MessageFilter());
+			msgFilter = new MessageFilter(this);
+			Application.AddMessageFilter(msgFilter);
 			_ = InitHook();//Why is this always being initialized even when there are no hooks? This is very inefficient.//TODO
 			//Init the API classes, passing in this which will be used to access their respective data objects.
 			Reflections = new ();
@@ -227,6 +229,12 @@ namespace Keysharp.Scripting
 			tickTimer.Elapsed += TickTimerCallback;
 			tickTimer.AutoReset = false;
 			tickTimer.Start();
+		}
+		
+		~Script()
+		{
+			tickTimer?.Dispose();
+			Application.RemoveMessageFilter(msgFilter);
 		}
 
 		[DebuggerStepThrough]

--- a/Keysharp.Core/Scripting/Script/Script.cs
+++ b/Keysharp.Core/Scripting/Script/Script.cs
@@ -305,7 +305,6 @@ namespace Keysharp.Scripting
 			if (Env.FindCommandLineArg("restart") != null || Env.FindCommandLineArg("r") != null)
 				inst = eScriptInstance.Force;
 
-			title = MakeTitleWithVersion(title);
 			var exit = false;
 			var oldDetect = WindowX.DetectHiddenWindows(true);
 			var oldMatchMode = WindowX.SetTitleMatchMode(3);//Require exact match.
@@ -372,7 +371,7 @@ namespace Keysharp.Scripting
 			mainWindow = new MainWindow();
 
 			if (!string.IsNullOrEmpty(title))
-				mainWindow.Text = MakeTitleWithVersion(title);
+				mainWindow.Text = title;
 
 			mainWindow.ClipboardUpdate += PrivateClipboardUpdate;
 			mainWindow.Icon = Core.Properties.Resources.Keysharp_ico;

--- a/Keysharp.Core/Scripting/Script/Variables.cs
+++ b/Keysharp.Core/Scripting/Script/Variables.cs
@@ -2,16 +2,8 @@ namespace Keysharp.Scripting
 {
 	public class Variables
 	{
-		internal List<(string, bool)> preloadedDlls = [];
 		internal DateTime startTime = DateTime.UtcNow;
 		private readonly Dictionary<string, MemberInfo> globalVars = new (StringComparer.OrdinalIgnoreCase);
-
-		/// <summary>
-		/// Will be a generated call within Main which calls into this class to add DLLs.
-		/// </summary>
-		/// <param name="p"></param>
-		/// <param name="s"></param>
-		public void AddPreLoadedDll(string p, bool s) => preloadedDlls.Add((p, s));
 
 		public Variables()
 		{

--- a/Keysharp.Core/Windows/WindowManager.cs
+++ b/Keysharp.Core/Windows/WindowManager.cs
@@ -130,7 +130,7 @@ namespace Keysharp.Core.Windows
 
 		internal override nint GetForeGroundWindowHwnd() => WindowsAPI.GetForegroundWindow();
 
-		internal override bool IsWindow(nint handle) => WindowsAPI.IsWindow(handle);
+		internal override bool IsWindow(nint handle) => WindowsAPI.IsWindow(handle) || handle == WindowsAPI.HWND_BROADCAST;
 
 		internal override void MaximizeAll()
 		{

--- a/Keysharp.Tests/Code/directive-misc.ahk
+++ b/Keysharp.Tests/Code/directive-misc.ahk
@@ -7,6 +7,7 @@
 #NOTRAYICON
 #SUSPENDEXEMPT 1
 #WINACTIVATEFORCE
+#DLLLOAD user32.dll
 
 if (A_ClipboardTimeout == 2000)
 	FileAppend, "pass", "*"

--- a/Keysharp.Tests/Code/external-dllcall.ahk
+++ b/Keysharp.Tests/Code/external-dllcall.ahk
@@ -264,3 +264,23 @@ if (result == 3) ; This is testing the conversion of long back to int.
 	FileAppend "pass", "*"
 else
 	FileAppend "fail", "*"
+
+Base64ToString(Base64)
+{
+	static CRYPT_STRING_BASE64 := 0x00000001
+
+	if !(DllCall("crypt32\CryptStringToBinaryW", "Str", Base64, "UInt", 0, "UInt", CRYPT_STRING_BASE64, "Ptr", 0, "UInt*", &Size := 0, "Ptr", 0, "Ptr", 0))
+		throw OSError()
+
+	String := Buffer(Size)
+	if !(DllCall("crypt32\CryptStringToBinaryW", "Str", Base64, "UInt", 0, "UInt", CRYPT_STRING_BASE64, "Ptr", String, "UInt*", Size, "Ptr", 0, "Ptr", 0))
+		throw OSError()
+
+	return StrGet(String, "UTF-8")
+}
+
+str := Base64ToString("VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==")
+if (str == "The quick brown fox jumps over the lazy dog")
+	FileAppend "pass", "*"
+else
+	FileAppend "fail", "*"

--- a/Keysharp.Tests/Code/external-onmessage.ahk
+++ b/Keysharp.Tests/Code/external-onmessage.ahk
@@ -1,0 +1,24 @@
+﻿WM_MY_BROADCAST := DllCall("RegisterWindowMessage", "Str", "MyUniqueBroadcastMessage", "UInt")
+HWND_BROADCAST := 0xFFFF
+OnMessage(WM_MY_BROADCAST, HandleMyBroadcast)
+
+HandleMyBroadcast(wParam, lParam, *) {
+    global result++
+}
+
+result := 0
+PostMessage(WM_MY_BROADCAST, 123, 456,, HWND_BROADCAST)
+Sleep 200
+
+if (result == 1)
+    FileAppend "pass", "*"
+else
+    FileAppend "fail", "*"
+
+result := 0
+SendMessage(WM_MY_BROADCAST, 123, 456,, A_ScriptHwnd)
+
+if (result == 1)
+    FileAppend "pass", "*"
+else
+    FileAppend "fail", "*"

--- a/Keysharp.Tests/ExternalTests.cs
+++ b/Keysharp.Tests/ExternalTests.cs
@@ -39,6 +39,9 @@ namespace Keysharp.Tests
 
 		[Test, Category("External")]
 		public void COM() => Assert.IsTrue(TestScript("external-com", false));
+
+		[Test, Category("External")]
+		public void OnMessage() => Assert.IsTrue(TestScript("external-onmessage", false));
 #endif
 	}
 }


### PR DESCRIPTION
1. I separated DllCall and ComCall return value handling from the DllCall/ComCall into ArgumentHelper, and added ComArgumentHelper to differentiate the source. This is mostly for maintenance purposes since I've forgotten to sync changes between the two before.
2. Fixed DllCall AStr return value handling.
3. Fixed DllCall str argument handling when the argument is a non-string (for example integers should be converted to string). I decided to not force objects into strings because that may lead to weird bugs for users, eg no error would be thrown if the user passes an array instead of accessing the array item as the user intended. The exception is IPointable mostly because of StringBuffer: perhaps this should be limited to *only* StringBuffer?
4. I removed the special WM_COPYDATA handling from MainWindow `WndProc` because WM_COPYDATA does not necessarily send strings, it can send arbitrary data and it should be up to the user to decide how to handle it. Plus now `OnMessage` behaviour with WM_COPYDATA matches AutoHotkey.
5. Changed A_LastError to use `GetLastPInvokeError()` instead of `GetLastWin32Error()` since the two should be mostly equivalent but the former is semantically more platform independent. Additionally, DllCall and ComCall now use `SetLastPInvokeError` in combination with `GetLastSystemError` to save the error state because in CLR the result of `GetLastSystemError` may be overwritten by internal functions.
6. Fixed `#DllLoad` which was broken probably after introducing `_ks_s`/`TheScript`. Now the preloading mechanism is replaced by a simple `LoadDll` call to preload the requested dll.
7. Changed script main window naming from `Filename - version` to just `Filename` to match AHK better and make locating the script window easier.
8. Added `HWND_BROADCAST` as an exception to `IsWindow()` because otherwise `PostMessage` doesn't work with it. This could possibly be an exception just in `PostMessage` but AHK recognizes it as a window globally so I left it like that (eg `MsgBox(WinExist(65535))` shows 65535).
9. Fixed `OnMessage` message detection for non-queued messages, a more thorough explanation is in KeysharpForm.cs `WndProc`. Queued messages go through MessageFilter and `WndProc` both, and non-queued go straight to `WndProc`, and duplicate calls of event handlers are avoided by stashing the message in the MessageFilter call and then checking for it in `WndProc`. This approach *should* be thread-safe because the main message loop which caters to WinForms runs on the main thread. Because some messages get modified in-between the two (eg WM_KEYDOWN -> WM_CHAR), then MessageFilter can't just be discarded. This approach should be Linux-compatible although I don't know what purpose MessageFilter and `WndProc` serve in Linux.