### PR TITLE
ComObjArray and misc fixes

### DIFF
--- a/Keysharp.Core/Common/Window/MainWindow.cs
+++ b/Keysharp.Core/Common/Window/MainWindow.cs
@@ -2,7 +2,7 @@
 {
 	public partial class MainWindow : KeysharpForm
 	{
-		public static Font OurDefaultFont = new ("Microsoft Sans Serif", 9F);
+		public static Font OurDefaultFont = new ("MS Shell Dlg", 8F);
 		internal FormWindowState lastWindowState = FormWindowState.Normal;
 #if WINDOWS
 		private readonly bool clipSuccess;

--- a/Keysharp.Core/Core/COM/Com.cs
+++ b/Keysharp.Core/Core/COM/Com.cs
@@ -39,21 +39,6 @@ namespace Keysharp.Core.COM
 			for (var i = 0; i < args.Length; i++)
 				lengths[i + 1] = args[i].Ai();
 
-			t = ConvertVarTypeToCLRType(vt);
-
-			if (t == typeof(object)) //Some special handling for objects
-			{
-				switch (vt)
-				{
-					case VarEnum.VT_DISPATCH: t = typeof(DispatchWrapper); break;
-
-					case VarEnum.VT_VARIANT: break;
-
-					default:
-						return Errors.ValueErrorOccurred($"The supplied COM type of {varType} is not supported.");
-				}
-			}
-
 			return new ComObjArray(vt, lengths);
 		}
 
@@ -348,7 +333,15 @@ namespace Keysharp.Core.COM
 			}
 		}
 
-		public static ComObject ComValue(object varType, object value, object flags = null) => new (varType, value, flags);
+		public static ComObject ComValue(object varType, object value, object flags = null)
+		{
+			var vt = (VarEnum)varType.Al();
+			if ((vt & VarEnum.VT_ARRAY) != 0) {
+				nint psa = (nint)Reflections.GetPtrProperty(value);
+				return new ComObjArray(vt & ~VarEnum.VT_ARRAY, psa, flags.Ab());
+			}
+			return new (varType, value, flags);
+		}
 
 		public static object ObjAddRef(object ptr)
 		{

--- a/Keysharp.Core/Core/COM/ComObjArray.cs
+++ b/Keysharp.Core/Core/COM/ComObjArray.cs
@@ -88,6 +88,13 @@ namespace Keysharp.Core.COM
 			[In] int[] rgIndices,
 			[MarshalAs(UnmanagedType.Struct)] object pv
 		);
+
+		// Raw-pointer version: for all non-VARIANT base types.
+		[DllImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayGetElement")]
+		public static extern int SafeArrayGetElementPtr(nint psa, [In] int[] rgIndices, IntPtr pv);
+
+		[DllImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayPutElement")]
+		public static extern int SafeArrayPutElementPtr(nint psa, [In] int[] rgIndices, IntPtr pv);
 	}
 
 	/// <summary>
@@ -99,6 +106,7 @@ namespace Keysharp.Core.COM
 		private readonly int _count;
 		private readonly int[] _indices;
 		private readonly int[] _flows; // upper bounds per dimension
+		private readonly int[] _lows;  // lower bounds per dimension
 		private bool _done;
 
 		/// <summary>
@@ -114,13 +122,21 @@ namespace Keysharp.Core.COM
 			int d = owner._dimensions;
 			_indices = new int[d];
 			_flows = new int[d];
+			_lows = new int[d];
 
 			for (int i = 0; i < d; i++)
 			{
-				// start one _below_ zero so first MoveNext() bumps to 0
-				_indices[i] = -1;
-				_flows[i] = (int)owner.MaxIndex(i + 1);
+				_flows[i] = (int)(long)owner.MaxIndex(i + 1);
+				_lows[i] = (int)(long)owner.MinIndex(i + 1);
 			}
+
+			// Initialize counter to just before the first element:
+			// set all but the last dimension to their low bound;
+			// set the last dimension to (low - 1) so first MoveNext() brings it to 'low'.
+			for (int i = 0; i < d; i++)
+				_indices[i] = _lows[i];
+
+			_indices[d - 1] = _lows[d - 1] - 1;
 
 			var script = Script.TheScript;
 			var p = c <= 1 ? script.ComArrayIndexValueEnumeratorData.p1 : script.ComArrayIndexValueEnumeratorData.p2;
@@ -155,14 +171,9 @@ namespace Keysharp.Core.COM
 		{
 			get
 			{
-				// 1-based AHK index is (idx+1) for the first dimension
-				object idx1 = (long)(_indices[0] + 1);
-				_ = OleAuto.SafeArrayGetElement(
-						_owner._psa,
-						_indices,
-						out object val
-					);
-				return (idx1, val);
+				long idx0 = (long)(_indices[0] - _lows[0]);
+				object val = _owner.GetElementAtIndices(_indices);
+				return (idx0, val);
 			}
 		}
 
@@ -174,34 +185,40 @@ namespace Keysharp.Core.COM
 
 			int d = _owner._dimensions;
 
-			// increment the n-dimensional counter:
+			// Increment the n-dimensional counter (row-major):
 			for (int dim = d - 1; dim >= 0; dim--)
 			{
-				_indices[dim]++;
+				int next = _indices[dim] + 1;
 
-				if (_indices[dim] <= _flows[dim])
+				if (next <= _flows[dim])
 				{
-					// done incrementing
-					break;
+					_indices[dim] = next;
+					// Reset trailing dimensions to their low bound.
+					for (int j = dim + 1; j < d; j++)
+						_indices[j] = _lows[j];
+
+					return true;
 				}
 
 				if (dim == 0)
 				{
-					// we overflowed the first dimension ⇒ end
 					_done = true;
 					return false;
 				}
-
-				// reset this dim and carry to next
-				_indices[dim] = 0;
 			}
 
-			return true;
+			_done = true;
+			return false;
 		}
 
 		public void Reset()
 		{
-			System.Array.Clear(_indices, 0, _indices.Length);
+			int d = _owner._dimensions;
+
+			for (int i = 0; i < d; i++)
+				_indices[i] = _lows[i];
+
+			_indices[d - 1] = _lows[d - 1] - 1;
 			_done = false;
 		}
 
@@ -265,6 +282,15 @@ namespace Keysharp.Core.COM
 		}
 
 		public KeysharpEnumerator __Enum(object count) => new ComArrayIndexValueEnumerator(this, count.Ai());
+		public ComObjArray(VarEnum baseType, nint psa, bool takeOwnership)
+		{
+			_baseType = baseType;
+			_dimensions = OleAuto.SafeArrayGetDim(psa);
+			_psa = psa;
+			this.vt = VarEnum.VT_ARRAY | baseType;
+			this.Flags = takeOwnership ? F_OWNVALUE : 0; ;
+			this.Ptr = _psa.ToInt64();
+		}
 
 		public IEnumerator<(object, object)> GetEnumerator() => new ComArrayIndexValueEnumerator(this, 2);
 
@@ -299,7 +325,7 @@ namespace Keysharp.Core.COM
 		}
 
 		/// <summary>
-		/// Indexer for direct element access using 1-based indices.
+		/// Indexer for direct element access using 0-based indices.
 		/// Negative indices count from the end.
 		/// </summary>
 		public object this[params object[] indices]
@@ -307,35 +333,15 @@ namespace Keysharp.Core.COM
 			get
 			{
 				int[] idx = ConvertIndices(indices);
-				int hr = OleAuto.SafeArrayGetElement(_psa, idx, out object val);
-				return Errors.OSErrorOccurredForHR(hr, val);
+				object val = GetElementAtIndices(idx);
+				return val;
 			}
 			set
 			{
 				int[] idx = ConvertIndices(indices);
-				int hr = OleAuto.SafeArrayPutElement(_psa, idx, value!);
+				int hr = PutElementAtIndices(idx, value!);
 				_ = Errors.OSErrorOccurredForHR(hr);
 			}
-		}
-
-		/// <summary>
-		/// Converts indices to ints and handles negative indices
-		/// </summary>
-		private int[] ConvertIndices(object[] indices)
-		{
-			int[] idx = new int[indices.Length];
-
-			for (int i = 0; i < idx.Length; i++)
-			{
-				int temp = indices[i].Ai();
-
-				if (temp < 0)
-					temp = Convert.ToInt32(MaxIndex((long)(i + 1))) + temp + 1;
-
-				idx[i] = temp;
-			}
-
-			return idx;
 		}
 
 		/// <summary>
@@ -362,12 +368,241 @@ namespace Keysharp.Core.COM
 			if ((Flags & F_OWNVALUE) != 0 && _psa != 0)
 			{
 				_ = OleAuto.SafeArrayDestroy(_psa);
+				_psa = 0;
 				// Clear the flag so we don't double‐destroy:
 				Flags &= ~F_OWNVALUE;
 			}
 
 			base.Dispose();
 		}
+
+
+		#region Helpers
+		/// <summary>
+		/// Converts indices to ints and handles negative indices
+		/// </summary>
+		private int[] ConvertIndices(object[] indices)
+		{
+			if (indices == null || indices.Length != _dimensions)
+				throw new Error($"Expected {_dimensions} index(es), got {indices?.Length ?? 0}.");
+
+			int[] idx = new int[indices.Length];
+
+			for (int i = 0; i < idx.Length; i++)
+			{
+				int temp = indices[i].Ai();
+
+				int lb = (int)(long)MinIndex(i + 1); // SAFEARRAY is 1-based for the dim parameter
+				int ub = (int)(long)MaxIndex(i + 1);
+
+				if (temp < 0)              // negative from end
+					temp = ub + temp + 1;  // e.g. -1 -> ub
+				else                       // 0-based to SAFEARRAY base
+					temp = lb + temp;
+
+				if (temp < lb || temp > ub)
+					throw new Error($"Index {i} out of range [{lb}, {ub}]");
+
+				idx[i] = temp;
+			}
+
+			return idx;
+		}
+
+		internal object GetElementAtIndices(int[] idx)
+		{
+			if (_baseType == VarEnum.VT_VARIANT)
+			{
+				int hrVar = OleAuto.SafeArrayGetElement(_psa, idx, out object val);
+				return Errors.OSErrorOccurredForHR(hrVar, val);
+			}
+
+			// Non-VARIANT element types: use pointer variant and marshal manually.
+			int bytes = ByteSizeForVarType(_baseType);
+			IntPtr pv = Marshal.AllocCoTaskMem(bytes);
+
+			try
+			{
+				int hr = OleAuto.SafeArrayGetElementPtr(_psa, idx, pv);
+
+				if (hr < 0)
+					return Errors.OSErrorOccurredForHR(hr);
+
+				return ReadVariant(pv, _baseType);
+			}
+			finally
+			{
+				Marshal.FreeCoTaskMem(pv);
+			}
+		}
+
+		internal int PutElementAtIndices(int[] idx, object value)
+		{
+			// VT_VARIANT arrays, let the marshaller coerce the type
+			if (_baseType == VarEnum.VT_VARIANT)
+				return OleAuto.SafeArrayPutElement(_psa, idx, value);
+
+			// Pointer element types: pass the pointer value directly (no staging buffer).
+			if (_baseType == VarEnum.VT_UNKNOWN || _baseType == VarEnum.VT_DISPATCH)
+			{
+				nint pIface = 0;
+				bool releaseInterface = false;
+
+				// Accept Ptr properties or a plain RCW
+				if (Marshal.IsComObject(value))
+				{
+					object src = value is ComObject c ? c.Ptr : value;
+					// Get a temporary COM pointer we own; SafeArray will AddRef its own copy.
+					pIface = (_baseType == VarEnum.VT_DISPATCH)
+							 ? Marshal.GetIDispatchForObject(src)
+							 : Marshal.GetIUnknownForObject(src);
+					releaseInterface = true;
+				}
+				else
+				{
+					// raw interface pointer → pass as-is; SafeArrayPutElement will AddRef.
+					pIface = (nint)Reflections.GetPtrProperty(value);
+					releaseInterface = false;
+				}
+
+				try
+				{
+					int hr = OleAuto.SafeArrayPutElementPtr(_psa, idx, pIface);
+					_ = Errors.OSErrorOccurredForHR(hr);
+					return hr;
+				}
+				finally
+				{
+					if (releaseInterface && pIface != 0)
+					{
+						try { Marshal.Release(pIface); } catch { }
+					}
+				}
+			}
+
+			if (_baseType == VarEnum.VT_BSTR)
+			{
+				// For BSTR, pass the BSTR pointer directly; the array will own & free it.
+				nint bstr = value == null ? 0 : Marshal.StringToBSTR(value.As());
+				int hr = OleAuto.SafeArrayPutElementPtr(_psa, idx, bstr);
+				_ = Errors.OSErrorOccurredForHR(hr);
+				return hr;
+			}
+
+			// All other (non-pointer) element types need to be put in a temporary buffer
+			// used by SafeArrayPutElement.
+			int bytes = ByteSizeForVarType(_baseType);
+			IntPtr pv = Marshal.AllocCoTaskMem(bytes);
+			try
+			{
+				WriteValueToBuffer(pv, _baseType, value);
+				int hr = OleAuto.SafeArrayPutElementPtr(_psa, idx, pv);
+				_ = Errors.OSErrorOccurredForHR(hr);
+				return hr;
+			}
+			finally
+			{
+				Marshal.FreeCoTaskMem(pv);
+			}
+		}
+
+		private static int ByteSizeForVarType(VarEnum vt)
+		{
+			switch (vt)
+			{
+				case VarEnum.VT_I1:
+				case VarEnum.VT_UI1:
+					return 1;
+				case VarEnum.VT_I2:
+				case VarEnum.VT_UI2:
+				case VarEnum.VT_BOOL:    // VARIANT_BOOL (short)
+					return 2;
+				case VarEnum.VT_I4:
+				case VarEnum.VT_UI4:
+					return 4;
+				case VarEnum.VT_R4:
+					return Marshal.SizeOf<float>();
+				case VarEnum.VT_I8:
+				case VarEnum.VT_UI8:
+					return 8;
+				case VarEnum.VT_R8:
+				case VarEnum.VT_DATE:    // DATE is a double (8 bytes)
+					return Marshal.SizeOf<double>();
+				case VarEnum.VT_DECIMAL:
+					return Marshal.SizeOf<decimal>();
+				case VarEnum.VT_BSTR:
+				case VarEnum.VT_UNKNOWN:
+				case VarEnum.VT_DISPATCH:
+					return IntPtr.Size; // pointer-sized storage
+				default:
+					// Fallback for other pointer-like types if ever needed.
+					return IntPtr.Size;
+			}
+		}
+
+		private static void WriteValueToBuffer(IntPtr pv, VarEnum vt, object value)
+		{
+			switch (vt)
+			{
+				case VarEnum.VT_I1:
+					Marshal.WriteByte(pv, unchecked((byte)Convert.ToSByte(value)));
+					break;
+				case VarEnum.VT_UI1:
+					Marshal.WriteByte(pv, Convert.ToByte(value));
+					break;
+				case VarEnum.VT_I2:
+					Marshal.WriteInt16(pv, Convert.ToInt16(value));
+					break;
+				case VarEnum.VT_UI2:
+					Marshal.WriteInt16(pv, unchecked((short)Convert.ToUInt16(value)));
+					break;
+				case VarEnum.VT_I4:
+					Marshal.WriteInt32(pv, Convert.ToInt32(value));
+					break;
+				case VarEnum.VT_UI4:
+					Marshal.WriteInt32(pv, unchecked((int)Convert.ToUInt32(value)));
+					break;
+				case VarEnum.VT_I8:
+					Marshal.WriteInt64(pv, Convert.ToInt64(value));
+					break;
+				case VarEnum.VT_UI8:
+					Marshal.WriteInt64(pv, unchecked((long)Convert.ToUInt64(value)));
+					break;
+				case VarEnum.VT_R4:
+					Marshal.StructureToPtr(Convert.ToSingle(value), pv, false);
+					break;
+				case VarEnum.VT_R8:
+					Marshal.StructureToPtr(Convert.ToDouble(value), pv, false);
+					break;
+				case VarEnum.VT_BOOL:
+					{
+						bool b = value is bool bb ? bb : (Convert.ToInt32(value) != 0);
+						Marshal.WriteInt16(pv, (short)(b ? -1 : 0));
+						break;
+					}
+				case VarEnum.VT_DATE:
+					{
+						double oa = value is DateTime dt ? dt.ToOADate() : Convert.ToDouble(value);
+						Marshal.StructureToPtr(oa, pv, false);
+						break;
+					}
+				case VarEnum.VT_DECIMAL:
+					Marshal.StructureToPtr(Convert.ToDecimal(value), pv, false);
+					break;
+				default:
+					{
+						// For any other pointer-like types, try to write pointer-sized data.
+						if (value is IntPtr ip)
+							Marshal.WriteIntPtr(pv, ip);
+						else if (value is nint nip)
+							Marshal.WriteIntPtr(pv, (IntPtr)nip);
+						else
+							Marshal.WriteIntPtr(pv, IntPtr.Zero);
+						break;
+					}
+			}
+		}
+		#endregion
 	}
 }
 #endif

--- a/Keysharp.Core/Core/COM/ComObject.cs
+++ b/Keysharp.Core/Core/COM/ComObject.cs
@@ -229,6 +229,17 @@ namespace Keysharp.Core.COM
 			nint dataPtr = (nint)ptrValue;
 			VarEnum vt = vtRaw & ~VarEnum.VT_BYREF;
 
+			if ((vt & VarEnum.VT_ARRAY) != 0)
+			{
+				VarEnum elemVt = vt & ~VarEnum.VT_ARRAY;
+				nint parray = Marshal.ReadIntPtr(dataPtr);
+				if (parray == 0)
+					return DefaultErrorObject;
+
+				// Wrap without owning: the VARIANT will destroy it on VariantClear.
+				return new ComObjArray(elemVt, parray, takeOwnership: false);
+			}
+
 			switch (vt)
 			{
 				// ── Integers → long ───────────────────────────────────────────────
@@ -451,6 +462,10 @@ namespace Keysharp.Core.COM
 					{
 						innerVt = VarEnum.VT_DISPATCH;
 					}
+					else if (value is ComObjArray coa)
+					{
+						innerVt = VarEnum.VT_ARRAY | coa._baseType;
+					}
 					else if (value is double)
 					{
 						innerVt = VarEnum.VT_R8;
@@ -479,9 +494,43 @@ namespace Keysharp.Core.COM
 				}
 				break;
 
+				// ── SAFEARRAYs (VT_ARRAY | T) ─────────────────────────────────────────────
+				case var _ when (vt & VarEnum.VT_ARRAY) != 0:
+				{
+					// vt holds VT_ARRAY|elemVT, payload is a SAFEARRAY*
+					VarEnum elemVt = vt & ~VarEnum.VT_ARRAY;
+
+					nint psaToStore = 0;
+
+					if (value is ComObjArray coa)
+					{
+						// Defensive: if element type differs, still allow but clone regardless.
+						// Clone so that the VARIANT owns its *own* SAFEARRAY (avoids double-destroy).
+						int hr = OleAuto.SafeArrayCopy(coa._psa, out nint psaCopy);
+						if (hr < 0)
+							throw Errors.OSError("SafeArrayCopy failed.", hr);
+
+						psaToStore = psaCopy;
+					}
+					else if (value is long lp)
+					{
+						psaToStore = (nint)lp; // caller gave us a raw SAFEARRAY*
+					}
+					else if (value is nint ip2)
+					{
+						psaToStore = ip2;
+					}
+					else
+					{
+						throw Errors.Error($"Cannot write VT_ARRAY payload from {value?.GetType().Name}.");
+					}
+
+					Marshal.WriteIntPtr(dataPtr, psaToStore);
+					break;
+				}
 				// ── Unsupported ────────────────────────────────────────────────
 				default:
-					throw new NotSupportedException($"Writing VARTYPE {vt} is not supported.");
+					throw Errors.Error($"Writing VARTYPE {vt} is not supported.");
 			}
 		}
 
@@ -666,7 +715,14 @@ namespace Keysharp.Core.COM
 			else if (Ptr is string str)
 				v.data.bstrVal = Marshal.StringToBSTR(str);
 			else if (Ptr is nint ip)
-				v.data.pdispVal = ip;//Works for COM interfaces, safearray and other pointer types.
+			{
+				if ((vt & VarEnum.VT_ARRAY) != 0)
+					v.data.parray = ip;     // SAFEARRAY*
+				else if (vt == VarEnum.VT_DISPATCH || vt == VarEnum.VT_UNKNOWN)
+					v.data.pdispVal = ip;   // IDispatch*/IUnknown*
+				else
+					v.data.pdispVal = ip;   // fallback
+			}
 			else if (Ptr is int i)
 				v.data.lVal = i;
 			else if (Ptr is uint ui)

--- a/Keysharp.Core/Core/Gui/Gui.cs
+++ b/Keysharp.Core/Core/Gui/Gui.cs
@@ -28,6 +28,7 @@
 		internal Dictionary<object, object> controls = [];
 		internal bool dpiscaling = true;
 		internal MenuBar menuBar;
+		bool marginsInit = false;
 
 		private static readonly Dictionary<string, Action<Gui, object>> showOptionsDkt = new ()
 		{
@@ -242,14 +243,30 @@
 
 		public long MarginX
 		{
-			get => form.Margin.Left;
-			set => form.Margin = new Padding((int)value, form.Margin.Top, (int)value, form.Margin.Bottom);
+			get
+			{
+				EnsureDefaultMargins();
+				return form.Margin.Left;
+			}
+			set
+			{
+				EnsureDefaultMargins();
+				form.Margin = new Padding((int)value, form.Margin.Top, (int)value, form.Margin.Bottom);
+			}
 		}
 
 		public long MarginY
 		{
-			get => form.Margin.Top;
-			set => form.Margin = new Padding(form.Margin.Left, (int)value, form.Margin.Right, (int)value);
+			get
+			{
+				EnsureDefaultMargins();
+				return form.Margin.Top;
+			}
+			set
+			{
+				EnsureDefaultMargins();
+				form.Margin = new Padding(form.Margin.Left, (int)value, form.Margin.Right, (int)value);
+			}
 		}
 
 		public MenuBar MenuBar
@@ -382,9 +399,6 @@
 				_ = Opt(options);
 				var formHandle = form.Handle;//Force the creation.
 				var handleStr = $"{formHandle}";
-				var x = (int)Math.Round(form.Font.Size * 1.25f);//Not really sure if Size is the same as height, like the documentation says.//TODO
-				var y = (int)Math.Round(form.Font.Size * 0.75f);
-				form.Margin = new Padding(x, y, x, y);
 				LastContainer = form;
 
 				//This will be added to allGuiHwnds on show.
@@ -396,8 +410,21 @@
 			return DefaultObject;
 		}
 
+		void EnsureDefaultMargins()
+		{
+			if (marginsInit) return;
+			float dpi = dpiscaling ? (float)A_ScreenDPI : 96f;
+			float dpiinv = 96F / dpi;
+			float fh = form.Font.GetHeight(dpi) * dpiinv;
+			int mx = (int)Math.Round(fh * 1.25f);
+			int my = (int)Math.Round(fh * 0.75f);
+			form.Margin = new Padding(mx, my, mx, my);
+			marginsInit = true;
+		}
+
 		public object Add(object obj0, object obj1 = null, object obj2 = null)
 		{
+			EnsureDefaultMargins();
 			var typeo = obj0.As();
 			var options = obj1.As();
 			var o = obj2;//The third argument needs to account for being an array in the case of combo/list boxes.
@@ -420,7 +447,8 @@
 				{
 					var lbl = new KeysharpLabel(opts.addstyle, opts.addexstyle, opts.remstyle, opts.remexstyle)
 					{
-						Font = Conversions.ConvertFont(form.Font)
+						Font = Conversions.ConvertFont(form.Font),
+						UseCompatibleTextRendering = true
 					};
 					ctrl = lbl;
 					holder = new Text(this, ctrl, typeo);
@@ -1382,8 +1410,25 @@
 							}
 							else if (ctrl is KeysharpLabel lbl)
 							{
-								lbl.MaximumSize = new Size(lbl.Width, 0);//This enforces wrapping at the specified width.
-								lbl.AutoSize = true;
+								bool hasW = opts.width != int.MinValue || opts.wp != int.MinValue;
+								bool hasH = opts.height != int.MinValue || opts.hp != int.MinValue;
+
+								if (hasW && !hasH)
+								{
+									lbl.AutoSize = true;
+									lbl.MinimumSize = new Size(lbl.Width, 0);
+									lbl.MaximumSize = new Size(lbl.Width, int.MaxValue);
+								}
+								else if (!hasW && hasH)
+								{
+									lbl.AutoSize = true;
+									lbl.MinimumSize = new Size(0, lbl.Height);
+									lbl.MaximumSize = new Size(int.MaxValue, lbl.Height);
+								} 
+								else if (!hasW && !hasH)
+								{
+									lbl.AutoSize = true;
+								}
 								goto heightdone;
 							}
 						}
@@ -1820,6 +1865,7 @@
 
 		public object Show(object obj = null)
 		{
+			EnsureDefaultMargins();
 			var s = obj.As();
 			bool /*center = false, cX = false, cY = false,*/ auto = false, min = false, max = false, restore = false, hide = false;
 			int?[] pos = [null, null, null, null];

--- a/Keysharp.Core/Core/Gui/GuiControl.cs
+++ b/Keysharp.Core/Core/Gui/GuiControl.cs
@@ -8,7 +8,7 @@
 			private WeakReference<Gui> gui;
 			private readonly List<IFuncObj> clickHandlers = [];
 			private readonly List<IFuncObj> doubleClickHandlers = [];
-			private bool DpiScaling => ((Gui)Gui).dpiscaling;
+			internal bool DpiScaling => ((Gui)Gui).dpiscaling;
 			private System.Windows.Forms.Control _control;
 
 			//Normal event handlers can't be used becaused they need to return a value.

--- a/Keysharp.Core/Core/Gui/ListViewHelper.cs
+++ b/Keysharp.Core/Core/Gui/ListViewHelper.cs
@@ -16,8 +16,6 @@
 			_ = insert >= 0 ? lv.Items.Insert(row = Math.Min(insert, lv.Items.Count), item) : lv.Items.Add(item);
 			ApplyListViewOptions(lv, item, lvo);
 
-			if (lv.Items.Count == 1)//Resize on the first item, don't do it for subsequent items because it takes too long. It will be done again when setting opts to +Redraw.
-				lv.SetListViewColumnSizes();
 
 			return row;
 		}
@@ -43,7 +41,10 @@
 			lv.BeginUpdate();
 
 			if (lvco.width.HasValue)
-				col.Width = lvco.width.Value;
+			{
+				var scale = !lv.GetGuiControl().DpiScaling ? 1.0 : A_ScaledScreenDPI;
+				col.Width = (int)(lvco.width.Value * scale);
+			}
 
 			if (lvco.auto.HasValue)
 				lv.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);

--- a/Keysharp.Core/Core/Math.cs
+++ b/Keysharp.Core/Core/Math.cs
@@ -230,14 +230,12 @@
 		/// <exception cref="TypeError">A <see cref="TypeError"/> exception is thrown if the conversion failed.</exception>
 		public static object Integer(object value)
 		{
-			try
-			{
-				return (long)(value is double d ? d : value.Ad());
-			}
-			catch (Exception)
-			{
-				return Errors.TypeErrorOccurred(value, typeof(double));
-			}
+			long l = 0; double d = 0.0;
+			if (value.ParseLong(ref l))
+				return l;
+			else if (value.ParseDouble(ref d, false, true))
+				return (long)d;
+			return Errors.TypeErrorOccurred(value, typeof(double));
 		}
 
 		/// <summary>

--- a/Keysharp.Core/Core/Types.cs
+++ b/Keysharp.Core/Core/Types.cs
@@ -137,11 +137,11 @@
 		public static long IsNumber(object value) => IsInteger(value) | IsFloat(value);
 
 		/// <summary>
-		/// Returns 1 if the specified value is derived from KeysharpObject, else 0.
+		/// Returns 1 if the specified value is derived from Any, else 0.
 		/// </summary>
 		/// <param name="value">The object to examine.</param>
 		/// <returns>1 if value is derived from KeysharpObject, else 0.</returns>
-		public static long IsObject(object value) => value is KeysharpObject ? 1L : 0L;
+		public static long IsObject(object value) => value is Any ? 1L : 0L;
 
 		/// <summary>
 		/// Returns 1 if the specified variable has been assigned a value, meaning it is not null, else 0.

--- a/Keysharp.Tests/Code/external-com.ahk
+++ b/Keysharp.Tests/Code/external-com.ahk
@@ -161,6 +161,35 @@ if (arr[2, 3] == 6)
 else
 	FileAppend, "fail", "*"
 
+arr := ComObjArray(VT_I4:=3, 3, 4)
+
+Loop 3 {
+	x := A_Index-1
+	Loop 4 {
+		y := A_Index-1
+		arr[x, y] := x * y
+	}
+}
+
+if (arr[2, 3] == 6)
+	FileAppend, "pass", "*"
+else
+	FileAppend, "fail", "*"
+
+IID_IUnknown := "{00000000-0000-0000-C000-000000000046}"
+CLSID_FileOpenDialog := "{DC1C5A9C-E88A-4DDE-A5A1-60F82A20AEF7}"
+p := ComObject(CLSID_FileOpenDialog, IID_IUnknown)  ; VT_UNKNOWN
+ObjAddRef(p.Ptr), before := ObjRelease(p.Ptr)
+arr := ComObjArray(13, 1)
+arr[0] := p
+ObjAddRef(p.Ptr), after := ObjRelease(p.Ptr)
+
+; Ref count should increase after adding it to the safe-array
+if (after == (before + 1))
+    FileAppend "pass", "*"
+else
+    FileAppend "fail", "*"
+
 script := "
 (
 	x := ComObjActive("{6B39CAA1-A320-4CB0-8DB4-352AA81E460E}")

--- a/Keysharp.Tests/Code/misc-is.ahk
+++ b/Keysharp.Tests/Code/misc-is.ahk
@@ -215,6 +215,11 @@ if (IsObject(m) == 1)
 else
 	FileAppend, "fail", "*"
 
+if (IsObject(ComObjArray(13, 1)) == 1)
+	FileAppend, "pass", "*"
+else
+	FileAppend, "fail", "*"
+
 if (IsDigit(1) == 1)
 	FileAppend, "pass", "*"
 else


### PR DESCRIPTION
1. ComValue was not returning a ComObjArray if VT_ARRAY was used so this is fixed now, and ComObjArray didn't support any types besides VT_VARIANT which needed some deeper fixes. It's mostly functioning now, at least I got some complex COM code working from my UIA library.
2. Fixed `Integer` to coerce strings into integers as well, and fixed `IsObject` to return true for objects deriving from Any, not KeysharpObject.
3. Changed GUI default font and font size to match AHK.
4. Fixed GUI MarginX and MarginY handling to match AHK.
5. Made some changes to GUI Text controls: first to use UseCompatibleTextRendering, and second to clamp the size if user specified one of width or height, because otherwise AutoSize may reduce or increase that dimension. These changes were needed so that with this code
```
g := Gui(, "Window")
text := g.AddText("w40", "Action:")
text.SetFont("Bold")
g.Show("w200 h200")
text.GetPos(&x, &y, &w, &h)
g.AddText(, "x" x " y" y " w" w " h" h)
```
the trailing colon would not be line-wrapped, and the location and size would mostly match AHK (the height still differs a bit).

With these changes I got my UIA library UIAViewer to look almost the same in Keysharp (ANTLR branch):
<img width="1805" height="871" alt="image" src="https://github.com/user-attachments/assets/3ff13e34-95d6-4d22-986d-008d692f577c" />
The button and textbox sizes still differ a bit causing the button text to wrap, I'm not sure what's the cause.