### PR TITLE
Fix FuncObj and BoundFunc Equals and GetHashCode

### DIFF
--- a/Keysharp.Core/Common/Invoke/FuncObj.cs
+++ b/Keysharp.Core/Common/Invoke/FuncObj.cs
@@ -67,6 +67,10 @@
 			}
 		}
 
+		public override bool Equals(object obj) => ReferenceEquals(this, obj);
+
+		public override int GetHashCode() => RuntimeHelpers.GetHashCode(this);
+
 		public override IFuncObj Bind(params object[] args)
 		{
 			object[] newbound = new object[boundargs.Length + args.Length];
@@ -261,11 +265,21 @@
 			return val;
 		}
 
-		public override bool Equals(object obj) => obj is FuncObj fo ? fo.mi == mi : false;
+		public override bool Equals(object obj)
+		{
+			if (obj is BoundFunc)
+				return false; // BoundFunc has its own Equals override and considers all instances unique
+			return obj is FuncObj fo ? fo.mi == mi && fo.Inst == Inst : false;
+		}
 
-		public bool Equals(FuncObj value) => value.mi == mi;
-
-		public override int GetHashCode() => mi.GetHashCode();
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				int h = mi?.GetHashCode() ?? 0;
+				return (h * 31) ^ (Inst != null ? RuntimeHelpers.GetHashCode(Inst) : 0);
+			}
+		}
 
 		public bool IsByRef(object obj = null)
 		{

--- a/Keysharp.Tests/FunctionLabelTests.cs
+++ b/Keysharp.Tests/FunctionLabelTests.cs
@@ -57,5 +57,20 @@ namespace Keysharp.Tests
 
 		[Test, Category("Function"), NonParallelizable]
 		public void VarParamsInFunc() => Assert.IsTrue(TestScript("func-var-params", false));
+
+		public object TestFunc(object a) => a;
+		[Test, Category("Function"), NonParallelizable]
+		public void FuncComparison()
+		{
+			var f1 = Keysharp.Core.Functions.Func(TestFunc);
+			var f2 = Keysharp.Core.Functions.Func(TestFunc, this);
+			Assert.AreEqual(f1, f1);
+			Assert.AreNotEqual(f1, f2);
+
+			var bf1 = f1.Bind("1");
+			var bf2 = f2.Bind("1");
+			Assert.AreNotEqual(f1, bf2);
+			Assert.AreNotEqual(bf1, bf2);
+		}
 	}
 }


### PR DESCRIPTION
1. Two FuncObj with same MethodInfo and instance (Inst) should equal and have the same hash
2. Two FuncObj with different MethodInfo and/or different instance should not equal. Additionally, previously a MethodInfo and a FuncObj with that MethodInfo resulted in the same hash, which probably is better not to happen.
3. BoundFunc should only equal its instance, even if the bound arguments equal. This matches AHK behavior.