### PR TITLE
GUI Picture fixes

### DIFF
--- a/Keysharp.Core/Common/ExtensionMethods/ObjectExtensions.cs
+++ b/Keysharp.Core/Common/ExtensionMethods/ObjectExtensions.cs
@@ -226,6 +226,7 @@
 
 			if (obj is long l)
 			{
+				if (requiredot) { outvar = default; return false; }
 				outvar = l;
 				return true;
 			}
@@ -237,6 +238,7 @@
 
 			if (obj is int i)//int is seldom used in Keysharp, so check last.
 			{
+				if (requiredot) { outvar = default; return false; }
 				outvar = i;
 				return true;
 			}

--- a/Keysharp.Core/Common/Images/ImageHelper.cs
+++ b/Keysharp.Core/Common/Images/ImageHelper.cs
@@ -252,8 +252,8 @@
 			if (w <= 0 && h <= 0)
 				return bmp;
 
-			if (w <= 0) w = bmp.Width;
-			if (h <= 0) h = bmp.Height;
+			if (w <= 0) w = h > 0 ? h : bmp.Width;
+			if (h <= 0) h = w > 0 ? w : bmp.Height;
 
 			if (bmp.Width != w || bmp.Height != h)
 				bmp = bmp.Resize(w, h);

--- a/Keysharp.Core/Core/Gui/Gui.cs
+++ b/Keysharp.Core/Core/Gui/Gui.cs
@@ -1676,12 +1676,6 @@
 						else
 							pbox.Height = (int)(pbox.Width / ratio);
 					}
-					else if (pbox.SizeMode == PictureBoxSizeMode.AutoSize && dpiscaling && dpiscale != 1.0)
-					{
-						pbox.SizeMode = PictureBoxSizeMode.Zoom;
-						pbox.Width = (int)(bmp.Width * dpiscale);
-						pbox.Height = (int)(bmp.Height * dpiscale);
-					}
 
 					pbox.Image = bmp;
 					//pbox.BackgroundImage = bmp;

--- a/Keysharp.Core/Core/Gui/Gui.cs
+++ b/Keysharp.Core/Core/Gui/Gui.cs
@@ -457,7 +457,7 @@
 					var lbl = new KeysharpLabel(opts.addstyle, opts.addexstyle, opts.remstyle, opts.remexstyle)
 					{
 						Font = Conversions.ConvertFont(form.Font),
-						UseCompatibleTextRendering = true
+						//UseCompatibleTextRendering = true // Using this will cause some fonts to display boxes instead of the proper characters
 					};
 					ctrl = lbl;
 					holder = new Text(this, ctrl, typeo);
@@ -1316,7 +1316,7 @@
 
 			if (opts.wp != int.MinValue)
 			{
-				w = lastControl != null ? lastControl.Width + opts.wp : 0.0;
+				w = lastControl != null ? lastControl.Width + opts.wp * dpiscale : 0.0;
 			}
 			else if (opts.width != int.MinValue)
 			{
@@ -1343,11 +1343,11 @@
 				w = fontpixels * 10;
 
 #endif
-			ctrl.Width = opts.width == int.MinValue ? Math.Max((int)w, (int)Math.Round(scaledPref)) : (holder.requestedSize.Width = (int)Math.Round(w));
+			ctrl.Width = opts.width == int.MinValue && opts.wp == int.MinValue ? Math.Max((int)w, (int)Math.Round(scaledPref)) : (holder.requestedSize.Width = (int)Math.Round(w));
 
 			if (opts.hp != int.MinValue)
 			{
-				ctrl.Height = lastControl != null ? lastControl.Height + opts.hp : 0;
+				ctrl.Height = lastControl != null ? lastControl.Height + (int)(opts.hp * dpiscale) : 0;
 			}
 			else
 			{

--- a/Keysharp.Core/Core/Gui/GuiControl.cs
+++ b/Keysharp.Core/Core/Gui/GuiControl.cs
@@ -354,38 +354,22 @@
 								}
 							}
 
-							//If neither were set, make one set and the other unset to force a resize internally
-							//so it will match the dimensions of what's already loaded.
-							if (width < 0 && height < 0)
-								width = pic.Height;
+							// If the value of a PictureBox is changed then the size of the box
+							// should remain the same and the picture should be centered in it.
+							// Otherwise the picture sizing logic is mostly the same as when initializing
+							// a PictureBox: negative width/height means fit to the size of the box,
+							// w0/h0 means use original size, positive size uses the custom size.
+
+							if (pic.SizeMode != PictureBoxSizeMode.CenterImage)
+								pic.SizeMode = PictureBoxSizeMode.CenterImage;
+
+							if (width == int.MinValue)
+								width = pic.Width;
+							if (height == int.MinValue)
+								height = pic.Height;
 
 							if (ImageHelper.LoadImage(filename, width, height, iconnumber).Item1 is Bitmap bmp)
 							{
-								if (pic.SizeMode == PictureBoxSizeMode.Zoom)
-								{
-									var ratio = bmp.Height != 0 ? (double)bmp.Width / bmp.Height : 1;
-
-									if (ratio == 0)
-										ratio = 1;
-
-									if (width > 0)
-										pic.Width = width;
-
-									if (height > 0)
-										pic.Height = height;
-
-									if (width < 0 && pic.ScaleWidth)
-										pic.Width = (int)(pic.Height * ratio);
-
-									if (height < 0 && pic.ScaleHeight)
-										pic.Height = (int)(pic.Width / ratio);
-								} 
-								else if (pic.SizeMode == PictureBoxSizeMode.AutoSize && DpiScaling)
-								{
-									pic.Width = (int)(pic.Width * A_ScaledScreenDPI);
-									pic.Height = (int)(pic.Height * A_ScaledScreenDPI);
-								}
-
 								var oldimage = pic.Image;
 								pic.Image = bmp;
 

--- a/Keysharp.Core/Core/Gui/KeysharpForm.cs
+++ b/Keysharp.Core/Core/Gui/KeysharpForm.cs
@@ -21,8 +21,7 @@
 			get
 			{
 				var cp = base.CreateParams;
-				cp.Style &= ~0x02000000; // Remove WS_CLIPCHILDREN
-				cp.ExStyle |= 0x02000000; // Add WM_EX_COMPOSITED
+				cp.ExStyle |= 0x02000000; // Add WS_EX_COMPOSITED
 				cp.Style |= addStyle;
 				cp.ExStyle |= addExStyle;
 				cp.Style &= ~removeStyle;

--- a/Keysharp.Core/Core/Gui/KeysharpForm.cs
+++ b/Keysharp.Core/Core/Gui/KeysharpForm.cs
@@ -21,6 +21,8 @@
 			get
 			{
 				var cp = base.CreateParams;
+				cp.Style &= ~0x02000000; // Remove WS_CLIPCHILDREN
+				cp.ExStyle |= 0x02000000; // Add WM_EX_COMPOSITED
 				cp.Style |= addStyle;
 				cp.ExStyle |= addExStyle;
 				cp.Style &= ~removeStyle;

--- a/Keysharp.Core/Core/Gui/Menu.cs
+++ b/Keysharp.Core/Core/Gui/Menu.cs
@@ -187,7 +187,7 @@
 
 			_ = menu.Items.Add(new ToolStripSeparator());
 			script.suspendMenuItem = (ToolStripMenuItem)Add("&Suspend Hotkeys", new FuncObj(suspend.Method, suspend.Target));
-			_ = Add("&Exit", new FuncObj(exitfunc.Method, exitfunc.Target));
+			_ = Add("E&xit", new FuncObj(exitfunc.Method, exitfunc.Target));
 			return DefaultObject;
 		}
 

--- a/Keysharp.Core/Core/Types.cs
+++ b/Keysharp.Core/Core/Types.cs
@@ -38,7 +38,7 @@
 		public static long IsAlpha(object value, object locale = null)
 		{
 			var s = value.As();
-			Func<char, bool> predicate = locale != null && locale.As().Equals("locale", StringComparison.OrdinalIgnoreCase) ? char.IsLetterOrDigit : char.IsLetterOrDigit;
+			Func<char, bool> predicate = locale != null && locale.As().Equals("locale", StringComparison.OrdinalIgnoreCase) ? char.IsLetter : char.IsAsciiLetter;
 			return s?.Length == 0 || s.All(predicate) ? 1L : 0L;
 		}
 

--- a/Keysharp.Core/Windows/WindowsAPI.cs
+++ b/Keysharp.Core/Windows/WindowsAPI.cs
@@ -1141,6 +1141,11 @@ namespace Keysharp.Core.Windows
 		internal const long ERROR_ALREADY_EXISTS = 183L;
 		internal const long ERROR_INVALID_HOOK_HANDLE = 1404L;
 
+		public const int IMAGE_ICON = 1;
+		public const int LR_DEFAULTCOLOR = 0x0000_0000;
+		public const int LR_LOADFROMFILE = 0x0000_0010;
+		public const int LR_CREATEDIBSECTION = 0x0000_2000;
+
 		internal const string dwmapi = "dwmapi.dll",
 							  kernel32 = "kernel32.dll",
 							  shell32 = "shell32.dll",
@@ -2109,6 +2114,12 @@ namespace Keysharp.Core.Windows
 
 		[DllImport(gdi32, CharSet = CharSet.Unicode)]
 		internal static extern bool DeleteObject(nint hObject);
+
+		[DllImport(user32, CharSet = CharSet.Unicode, SetLastError = true)]
+		internal static extern IntPtr LoadImage(nint hinst, string lpszName, uint uType, int cxDesired, int cyDesired, uint fuLoad);
+
+		[DllImport(user32, CharSet = CharSet.Unicode, SetLastError = true)]
+		internal static extern uint PrivateExtractIcons(string lpszFile, int nIconIndex, int cxIcon, int cyIcon, [Out] nint[] phicon, [Out] uint[] piconid, uint nIcons, uint flags);
 
 		internal delegate bool _EnumWindowsProc(nint hwnd, int lParam);//Add an underscore to this name because some sample programs use EnumWindowsProc as a function name.
 


### PR DESCRIPTION
Most of the changes are related to GUI control sizing and PictureBox image handling:
```
g := Gui()
g.AddText("x0 y0 w100 h100 BackgroundTrans")
; Creates empty picturebox 
pic := g.AddPicture("xp yp wp hp 0x201") ; 0x201 == SS_CENTERIMAGE | SS_CENTER
; *w0 and *h0 forces use of original picture size
pic.Value := "*w0 *h0 HICON:" LoadPicture(A_WinDir "\System32\setupapi.dll", "w64 h64 GDI+ Icon44", &IT)
g.Show()
```
<img width="167" height="205" alt="image" src="https://github.com/user-attachments/assets/a2c7ceb7-37b7-4b5f-bed1-cd6be77671b0" />
<img width="178" height="205" alt="image" src="https://github.com/user-attachments/assets/1618c174-cb4d-4468-a07e-e23da0845c25" />

```
g := Gui()
g.AddText("x0 y0 w100 h100 BackgroundTrans")
; Creates empty picturebox 
pic := g.AddPicture("xp yp wp hp 0x201") ; 0x201 == SS_CENTERIMAGE | SS_CENTER
; *w0 forces original width, but height should adjust to the picture box
pic.Value := "*w0 HICON:" LoadPicture(A_WinDir "\System32\setupapi.dll", "w64 h64 GDI+ Icon44", &IT)
g.Show()
```
<img width="167" height="205" alt="image" src="https://github.com/user-attachments/assets/6fc024c1-bf59-4e3c-a768-b234c8257585" />
<img width="178" height="205" alt="image" src="https://github.com/user-attachments/assets/469851db-bff7-457c-a1fd-98d458f4d02c" />

```
g := Gui()
g.AddText("x0 y0 w100 h100 BackgroundTrans")
; Creates empty picturebox 
pic := g.AddPicture("xp yp wp hp 0x201") ; 0x201 == SS_CENTERIMAGE | SS_CENTER
; *h40 requests height 40 and *w-1 requests the same as the other dimension (meaning 40)
pic.Value := "*w-1 *h40 HICON:" LoadPicture(A_WinDir "\System32\setupapi.dll", "w64 h64 GDI+ Icon44", &IT)
g.Show()
```
<img width="167" height="205" alt="image" src="https://github.com/user-attachments/assets/f5ece01a-6678-4417-8d22-f7eb7f267384" />
<img width="178" height="205" alt="image" src="https://github.com/user-attachments/assets/612457de-2ae4-42bf-8d86-e757958f6867" />

Use of WS_EX_COMPOSITED is related to GDI use. This is a function by [SKAN](https://www.autohotkey.com/boards/viewtopic.php?f=83&t=139027):
```
SegoeBMP(W?, Background?, P*)  ;  v0.32 by SKAN for WiseGui.ah2 on D859/D89D @ autohotkey.com/r?p=609741
{
    If ( W = "" and Background == "HwndToBMP" )
         Return HwndToBMP.Bind()

    Local  G := Gui("+DpiScale -Caption +ToolWindow", "SegoeBMP\"),  H := W

    G.SetFont("q4 s" Round(W * 0.75), "Segoe MDL2 Assets")
    G.MarginY := ( G.MarginX := 0 )

    If ( InStr(Background ?? "", ":", True) )
         G.AddPicture("x0 y0", Background).GetPos(,, &W, &H)
       , G.AddText(Format("x0 y0 w{1:} h{1:} BackgroundTrans", W))
    Else G.AddText(Format("x0 y0 w{1:} h{1:} Background{2:}",  W, Background ?? "Trans"))

    Loop P.Length
         If ( InStr(P[A_Index], ":", True) )
              G.AddPicture(      "x0 y0 wp hp 0x201 BackgroundTrans").Value := "*w0 *h0 " P[A_Index]
         Else G.AddText(StrSplit("x0 y0 wp hp 0x201 BackgroundTrans c" P[A_Index], ",")*)

    WinSetTransparent(0, G)
    G.Show("NA")

                    HwndToBMP(Hwnd, W, H, X := 0, Y := 0)
                    {
                        W := IsFloat(W)  ? Floor(W) * (A_ScreenDPI / 96) : W
                        H := IsFloat(H)  ? Floor(H) * (A_ScreenDPI / 96) : H
                        
                        Local  sDC := DllCall("User32\GetDC", "ptr",Hwnd, "ptr")
                            ,  tDC := DllCall("Gdi32\CreateCompatibleDC", "ptr",sDC, "ptr")
                            ,  tBM := DllCall( "Gdi32\CreateCompatibleBitmap"
                                             , "ptr",sDC, "int",W, "int",H, "ptr" )

                        DllCall("Gdi32\SaveDC", "ptr",tDC)
                        DllCall("Gdi32\SelectObject", "ptr",tDC, "ptr",tBM)
                        DllCall( "Gdi32\BitBlt", "ptr",tDC, "int",0, "int",0, "int",W, "int",H
                                               , "ptr",sDC, "int",X, "int",Y, "int",0x40CC0020 )
                                               ;  CAPTUREBLT = 0x40000000 | SRCCOPY = 0xCC0020 

                        DllCall("User32\ReleaseDC", "ptr",Hwnd, "ptr",sDC)
                        DllCall("Gdi32\RestoreDC", "ptr",tDC, "int",-1)
                        DllCall("Gdi32\DeleteDC", "ptr",tDC)

                        Return tBM
                    }

    G.tBM := HwndToBMP(G.Hwnd, Float(W), Float(H))
    G.Destroy()
    Return G.tBM
}

MyGui := Gui()
MyGui.SetFont("s10", "Segoe UI")
MyGui.AddPicture("xm y+m", "HBITMAP:" SegoeBMP( 64, 
                                              , "622F22," Chr(0xF136)    ; StatusCircleOuter
                                              , "FFFFF0," Chr(0xF137)    ; StatusCircleInner
                                              , "622F22," Chr(0xF13C)    ; StatusCircleExclamation
                                              ) )
MyGui.Show()
```
<img width="136" height="164" alt="image" src="https://github.com/user-attachments/assets/a2f7064b-cf4c-4a9f-955f-55d2c3eb073d" />
<img width="178" height="175" alt="image" src="https://github.com/user-attachments/assets/27925b0e-aa0f-4d40-9fcd-fad718864e75" />

Before the changes the GUI was simply empty. Now the image displays, but is clipped because of extra padding on the left side due to accommodating for glyph overhang. AHK doesn't do that, so stuff like this happens:
```
g := Gui()
g.SetFont("italic s36", "Times New Roman")
t := g.AddText(,"Jello")
g.Show()
```
<img width="278" height="209" alt="image" src="https://github.com/user-attachments/assets/63249a94-c301-49d2-b362-cc4eb7f5c733" />
<img width="315" height="209" alt="image" src="https://github.com/user-attachments/assets/2faa6b54-4c12-41ed-9d63-ef15a6c1a13c" />
Notice the "J" is clipped on the left.