### PR TITLE
Replaced most DllImport with LibraryImport & misc fixes

### DIFF
--- a/Keysharp.Core/Common/Input/InputType.cs
+++ b/Keysharp.Core/Common/Input/InputType.cs
@@ -219,11 +219,11 @@ namespace Keysharp.Core.Common.Input
 							// between a key press and a key release. The scan code is used for translating ALT+
 							// number key combinations.
 							var state = new byte[256];
-							var sb = new StringBuilder();
+							var ch = new char[2];
 							state[(int)Keys.ShiftKey] |= 0x80; // Indicate that the neutral shift key is down for conversion purposes.
 							var active_window_keybd_layout = hook.kbdMsSender.GetFocusedKeybdLayout(0);
 							var count = script.PlatformProvider.Manager.ToUnicodeEx(endingVK, hook.MapVkToSc(endingVK), state // Nothing is done about ToAsciiEx's dead key side-effects here because it seems to rare to be worth it (assuming its even a problem).
-										, sb, 2, script.menuIsVisible != MenuType.None ? 1u : 0u, active_window_keybd_layout); // v1.0.44.03: Changed to call ToAsciiEx() so that active window's layout can be specified (see hook.cpp for details).
+										, ch, 2, script.menuIsVisible != MenuType.None ? 1u : 0u, active_window_keybd_layout); // v1.0.44.03: Changed to call ToAsciiEx() so that active window's layout can be specified (see hook.cpp for details).
 							keyName = keyName.Substring(0, count);
 						}
 						else

--- a/Keysharp.Core/Common/Platform/PlatformManagerBase.cs
+++ b/Keysharp.Core/Common/Platform/PlatformManagerBase.cs
@@ -65,7 +65,7 @@
 
 		internal abstract bool SetDllDirectory(string path);
 
-		internal abstract int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, StringBuilder pwszBuff, int cchBuff, uint wFlags, nint dwhkl);
+		internal abstract int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out] char[] pwszBuff, int cchBuff, uint wFlags, nint dwhkl);
 
 		internal abstract bool UnregisterHotKey(nint hWnd, uint id);
 	}

--- a/Keysharp.Core/Common/Platform/WindowManagerBase.cs
+++ b/Keysharp.Core/Common/Platform/WindowManagerBase.cs
@@ -34,6 +34,13 @@ namespace Keysharp.Core.Common.Platform
 			if (criteria.IsEmpty)
 				return found;
 
+			if (criteria.ID != 0)
+			{
+				if (IsWindow(criteria.ID) && CreateWindow(criteria.ID) is WindowItemBase temp && temp.Equals(criteria))
+					return temp;
+				return null;
+			}
+
 			foreach (var window in AllWindows)
 			{
 				if (window.Equals(criteria))

--- a/Keysharp.Core/Common/Platform/WindowManagerBase.cs
+++ b/Keysharp.Core/Common/Platform/WindowManagerBase.cs
@@ -170,6 +170,6 @@ namespace Keysharp.Core.Common.Platform
 
 		internal abstract void MinimizeAllUndo();
 
-		internal abstract WindowItemBase WindowFromPoint(Point location);
+		internal abstract WindowItemBase WindowFromPoint(POINT location);
 	}
 }

--- a/Keysharp.Core/Common/Window/WindowItemBase.cs
+++ b/Keysharp.Core/Common/Window/WindowItemBase.cs
@@ -383,10 +383,7 @@
 
 				case 4:
 				{
-					object outvar = null;
-					_ = RegEx.RegExMatch(a, b, ref outvar, 1);
-					RegExMatchInfo output = (RegExMatchInfo)outvar;
-					return output.Count.Ai() > 0 && !string.IsNullOrEmpty(output[0]);
+					return RegEx.RegExMatch(a, b) is long ll && ll > 0L;
 				}
 			}
 

--- a/Keysharp.Core/Common/Window/WindowItemBase.cs
+++ b/Keysharp.Core/Common/Window/WindowItemBase.cs
@@ -5,10 +5,11 @@
 		internal double distanceFound = 0.0;
 		internal nint hwndFound = 0;
 		internal bool ignoreDisabled = false;
-		internal Point pt;
+		internal POINT pt;
 		internal Rectangle rectFound = new ();
 
-		internal PointAndHwnd(Point p) => pt = p;
+		internal PointAndHwnd(POINT p) => pt = p;
+		internal PointAndHwnd(Point p) => pt = new POINT(p);
 	}
 
 	/// <summary>
@@ -193,9 +194,9 @@
 		/// <param name="location"></param>
 		internal abstract void ClickRight(Point? location = null);
 
-		internal abstract Point ClientToScreen();
+		internal abstract POINT ClientToScreen();
 
-		internal virtual void ClientToScreen(ref Point pt)
+		internal virtual void ClientToScreen(ref POINT pt)
 		{
 			var screenPt = ClientToScreen();
 			pt.X += screenPt.X;

--- a/Keysharp.Core/Core/COM/ComObjArray.cs
+++ b/Keysharp.Core/Core/COM/ComObjArray.cs
@@ -20,7 +20,7 @@ namespace Keysharp.Core.COM
 	/// <summary>
 	/// Contains P/Invoke declarations for OLE Automation SafeArray APIs.
 	/// </summary>
-	static class OleAuto
+	static partial class OleAuto
 	{
 		/// <summary>
 		/// Creates a new SafeArray of the specified variant type and dimensions.
@@ -29,8 +29,8 @@ namespace Keysharp.Core.COM
 		/// <param name="cDims">The number of dimensions (1-8).</param>
 		/// <param name="rgsabound">Array of bounds for each dimension.</param>
 		/// <returns>A pointer to the new SAFEARRAY; IntPtr.Zero on failure.</returns>
-		[DllImport(WindowsAPI.oleaut)]
-		public static extern nint SafeArrayCreate(
+		[LibraryImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayCreate")]
+		public static partial nint SafeArrayCreate(
 			short vt,
 			uint cDims,
 			[In] SAFEARRAYBOUND[] rgsabound);
@@ -39,37 +39,37 @@ namespace Keysharp.Core.COM
 		/// </summary>
 		/// <param name="psa">Pointer to the SAFEARRAY.</param>
 		/// <returns>The number of dimensions, or a negative error code.</returns>
-		[DllImport(WindowsAPI.oleaut)]
-		public static extern int SafeArrayGetDim(
+		[LibraryImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayGetDim")]
+		public static partial int SafeArrayGetDim(
 			nint psa);
 		/// <summary>
 		/// Retrieves the upper bound (max index) for a specified dimension.
 		/// </summary>
-		[DllImport(WindowsAPI.oleaut)]
-		public static extern int SafeArrayGetUBound(
+		[LibraryImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayGetUBound")]
+		public static partial int SafeArrayGetUBound(
 			nint psa,
 			uint nDim,
 			out int plUbound);
 		/// <summary>
 		/// Retrieves the lower bound for a specified dimension.
 		/// </summary>
-		[DllImport(WindowsAPI.oleaut)]
-		public static extern int SafeArrayGetLBound(
+		[LibraryImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayGetLBound")]
+		public static partial int SafeArrayGetLBound(
 			nint psa,
 			uint nDim,
 			out int plLbound);
 		/// <summary>
 		/// Creates a copy of a SafeArray.
 		/// </summary>
-		[DllImport(WindowsAPI.oleaut)]
-		public static extern int SafeArrayCopy(
+		[LibraryImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayCopy")]
+		public static partial int SafeArrayCopy(
 			nint psa,
 			out nint ppsaOut);
 		/// <summary>
 		/// Destroys a SafeArray, releasing its memory.
 		/// </summary>
-		[DllImport(WindowsAPI.oleaut)]
-		public static extern int SafeArrayDestroy(
+		[LibraryImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayDestroy")]
+		public static partial int SafeArrayDestroy(
 			nint psa);
 		/// <summary>
 		/// Retrieves an element from a SafeArray by index.
@@ -90,11 +90,11 @@ namespace Keysharp.Core.COM
 		);
 
 		// Raw-pointer version: for all non-VARIANT base types.
-		[DllImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayGetElement")]
-		public static extern int SafeArrayGetElementPtr(nint psa, [In] int[] rgIndices, IntPtr pv);
+		[LibraryImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayGetElement")]
+		public static partial int SafeArrayGetElementPtr(nint psa, [In] int[] rgIndices, IntPtr pv);
 
-		[DllImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayPutElement")]
-		public static extern int SafeArrayPutElementPtr(nint psa, [In] int[] rgIndices, IntPtr pv);
+		[LibraryImport(WindowsAPI.oleaut, EntryPoint = "SafeArrayPutElement")]
+		public static partial int SafeArrayPutElementPtr(nint psa, [In] int[] rgIndices, IntPtr pv);
 	}
 
 	/// <summary>

--- a/Keysharp.Core/Core/COM/ComObject.cs
+++ b/Keysharp.Core/Core/COM/ComObject.cs
@@ -674,9 +674,8 @@ namespace Keysharp.Core.COM
 			if (co.vt != varType)//Attempt to coerce var to the correct type.
 			{
 				var origVal = co.Ptr;
-				var newVal = co.Ptr;
 
-				if (Com.VariantChangeTypeEx(out newVal, ref origVal, Thread.CurrentThread.CurrentCulture.LCID, 0, (short)varType) < 0)
+				if (Com.VariantChangeTypeEx(out object newVal, origVal, Thread.CurrentThread.CurrentCulture.LCID, 0, (ushort)varType) != 0)
 				{
 					co.Clear();
 					return null;

--- a/Keysharp.Core/Core/COM/ComVariant.cs
+++ b/Keysharp.Core/Core/COM/ComVariant.cs
@@ -73,13 +73,13 @@ namespace Keysharp.Core.COM
 		internal const ushort VT_UNKNOWN = 13;
 		//Extend as needed…
 	}
-	internal static class VariantHelper
+	internal static partial class VariantHelper
 	{
 		//Clears the VARIANT and frees any allocated memory (such as BSTRs).
-		[DllImport(WindowsAPI.oleaut, PreserveSig = false)]
-		internal static extern int VariantClear(ref VARIANT variant);
-		[DllImport(WindowsAPI.oleaut, PreserveSig = true)]
-		internal static extern int VariantClear(nint pvarg);
+		[LibraryImport(WindowsAPI.oleaut, EntryPoint = "VariantClear")]
+		internal static partial int VariantClear(ref VARIANT variant);
+		[LibraryImport(WindowsAPI.oleaut, EntryPoint = "VariantClear")]
+		internal static partial int VariantClear(nint pvarg);
 
 		internal static VARIANT CreateVariantFromInt(int value)
 		{

--- a/Keysharp.Core/Core/Flow.cs
+++ b/Keysharp.Core/Core/Flow.cs
@@ -486,8 +486,10 @@ namespace Keysharp.Core
 			//Be careful with Application.DoEvents(), it has caused spurious crashes in my years of programming experience.
 			if (d == 0L)
 			{
-				TryDoEvents();
-				System.Threading.Thread.Sleep(0);
+				var tc = Environment.TickCount;
+				TryDoEvents(true, false);
+				if (Environment.TickCount - tc == 0)
+					System.Threading.Thread.Sleep(0);
 			}
 			else if (d == -1L)
 			{

--- a/Keysharp.Core/Core/Gui/Controls.cs
+++ b/Keysharp.Core/Core/Gui/Controls.cs
@@ -176,7 +176,7 @@ namespace Keysharp.Core
 	}
 
 #if WINDOWS
-	public class KeysharpCustomControl : Control
+	public partial class KeysharpCustomControl : Control
 	{
 		private static readonly int ICC_ANIMATE_CLASS      = 0x00000080;
 		private static readonly int ICC_BAR_CLASSES        = 0x00000004;
@@ -256,8 +256,9 @@ namespace Keysharp.Core
 				base.WndProc(ref m);
 		}
 
-		[DllImport("comctl32.dll", SetLastError = true)]
-		private static extern bool InitCommonControlsEx(ref INITCOMMONCONTROLSEX icce);
+		[LibraryImport("comctl32.dll", EntryPoint = "InitCommonControlsEx", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		private static partial bool InitCommonControlsEx(ref INITCOMMONCONTROLSEX icce);
 
 		// comboex
 		[StructLayout(LayoutKind.Sequential)]

--- a/Keysharp.Core/Core/Gui/Gui.cs
+++ b/Keysharp.Core/Core/Gui/Gui.cs
@@ -427,8 +427,8 @@
 			float dpi = dpiscaling ? (float)A_ScreenDPI : 96f;
 			float dpiinv = 96F / dpi;
 			float fh = form.Font.GetHeight(dpi) * dpiinv;
-			int mx = (int)Math.Round(fh * 1.25f);
-			int my = (int)Math.Round(fh * 0.75f);
+			int mx = (int)Math.Ceiling(fh * 1.25f);
+			int my = (int)Math.Ceiling(fh * 0.75f);
 			form.Margin = new Padding(mx, my, mx, my);
 			marginsInit = true;
 		}
@@ -2078,6 +2078,12 @@
 			{
 				hadLocation = true;
 				location.Y = ((screen.Height - form.Size.Height) / 2) + screen.Y;
+			}
+
+			if (!form.BeenShown)
+			{
+				if (requestedSize.Width == int.MinValue) requestedSize.Width = (int)Math.Ceiling(form.Size.Width / dpiscale);
+				if (requestedSize.Height == int.MinValue) requestedSize.Height = (int)Math.Ceiling(form.Size.Height / dpiscale);
 			}
 
 			showCalled = true;

--- a/Keysharp.Core/Core/Gui/Gui.cs
+++ b/Keysharp.Core/Core/Gui/Gui.cs
@@ -30,6 +30,8 @@
 		internal MenuBar menuBar;
 		bool marginsInit = false;
 		internal nint owner = 0;
+		internal Size requestedSize = new(int.MinValue, int.MinValue);
+		internal Point requestedLocation = new(int.MinValue, int.MinValue);
 
 		private static readonly Dictionary<string, Action<Gui, object>> showOptionsDkt = new (StringComparer.OrdinalIgnoreCase)
 		{
@@ -1899,7 +1901,6 @@
 			EnsureDefaultMargins();
 			var s = obj.As();
 			bool /*center = false, cX = false, cY = false,*/ auto = false, min = false, max = false, restore = true, hide = false;
-			int?[] pos = [null, null, null, null];
 			var dpiscale = !dpiscaling ? 1.0 : A_ScaledScreenDPI;
 
 			foreach (Range r in s.AsSpan().SplitAny(Spaces))
@@ -1972,7 +1973,15 @@
 							//  cY = true;
 						}
 						else if (modeval.Length != 0 && int.TryParse(modeval, out var n))
-							pos[select] = n;
+						{
+							switch (select)
+							{
+								case 0: requestedSize.Width = n; break;
+								case 1: requestedSize.Height = n; break;
+								case 2: requestedLocation.X = n; break;
+								case 3: requestedLocation.Y = n; break;
+							}
+						}
 					}
 				}
 			}
@@ -2004,7 +2013,7 @@
 			}
 			int maxx = 0, maxy = 0, ssHeight = 0;
 
-			if (auto || pos[0] == null || pos[1] == null)
+			if (auto || requestedSize.Width == int.MinValue || requestedSize.Height == int.MinValue)
 			{
 				KeysharpStatusStrip ss = null;
 
@@ -2017,7 +2026,7 @@
 				(maxx, maxy) = FixStatusStrip(ss);
 			}
 
-			if (auto || (!form.BeenShown && !showCalled && pos[0] == null && pos[1] == null))//The calculations in this block are not exact, but are as close as we can possibly get in a generic way.
+			if (auto || (!form.BeenShown && !showCalled && requestedSize.Width == int.MinValue && requestedSize.Height == int.MinValue))//The calculations in this block are not exact, but are as close as we can possibly get in a generic way.
 			{
 				//AHK always autosizes on first show when no dimensions are specified.
 				form.ClientSize = new Size(maxx + form.Margin.Left,
@@ -2027,13 +2036,13 @@
 			{
 				var size = (form.BeenShown || showCalled) ? form.Size : new Size(800, 500);//Using this size because PreferredSize is so small it just shows the title bar.
 
-				if (pos[0] != null)
-					size.Width = (int)Math.Ceiling(pos[0].Value * dpiscale);
+				if (requestedSize.Width != int.MinValue)
+					size.Width = (int)Math.Ceiling(requestedSize.Width * dpiscale);
 				else
 					size.Width = (int)(maxx + MarginX);
 
-				if (pos[1] != null)
-					size.Height = (int)Math.Ceiling(pos[1].Value * dpiscale);
+				if (requestedSize.Height != int.MinValue)
+					size.Height = (int)Math.Ceiling(requestedSize.Height * dpiscale);
 				else
 					size.Height = (int)(maxy + ssHeight + MarginY);
 
@@ -2049,10 +2058,10 @@
 			//Then called Show() again to actually show the window.
 			//So don't set the location if it wasn't specified and Show() has already been called once.
 			//Same above with size.
-			if (pos[2] != null)//Strangely, the position does not need to be scaled by DPI.
+			if (requestedLocation.X != int.MinValue)//Strangely, the position does not need to be scaled by DPI.
 			{
 				hadLocation = true;
-				location.X = (int)pos[2];
+				location.X = requestedLocation.X;
 			}
 			else if (!showCalled && !form.BeenShown)
 			{
@@ -2060,10 +2069,10 @@
 				location.X = ((screen.Width - form.Size.Width) / 2) + screen.X;
 			}
 
-			if (pos[3] != null)
+			if (requestedLocation.Y != int.MinValue)
 			{
 				hadLocation = true;
-				location.Y = (int)pos[3];
+				location.Y = requestedLocation.Y;
 			}
 			else if (!showCalled && !form.BeenShown)
 			{

--- a/Keysharp.Core/Core/Gui/GuiControl.cs
+++ b/Keysharp.Core/Core/Gui/GuiControl.cs
@@ -1913,10 +1913,10 @@
 				else
 				{
 					var scale = 1.0 / A_ScaledScreenDPI;
-					x = (long)(rect.X * scale);
-					y = (long)(rect.Y * scale);
-					w = (long)(rect.Width * scale);
-					h = (long)(rect.Height * scale);
+					x = (long)Math.Ceiling(rect.X * scale);
+					y = (long)Math.Ceiling(rect.Y * scale);
+					w = (long)Math.Ceiling(rect.Width * scale);
+					h = (long)Math.Ceiling(rect.Height * scale);
 				}
 			}
 

--- a/Keysharp.Core/Core/Gui/GuiHelper.cs
+++ b/Keysharp.Core/Core/Gui/GuiHelper.cs
@@ -367,7 +367,7 @@ namespace Keysharp.Core
 	}
 
 #if WINDOWS
-	internal static class HFontCache
+	internal static partial class HFontCache
 	{
 		private sealed class Entry : IDisposable
 		{
@@ -420,11 +420,12 @@ namespace Keysharp.Core
 			}
 		}
 
-		[DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
+		[DllImport(WindowsAPI.gdi32)]
 		public static extern int GetObject(nint hgdiobj, int cbBuffer, out LOGFONT lpvObject);
 
-		[System.Runtime.InteropServices.DllImport("gdi32.dll")]
-		internal static extern bool DeleteObject(nint hObject);
+		[LibraryImport(WindowsAPI.gdi32, EntryPoint = "DeleteObject")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool DeleteObject(nint hObject);
 
 
 	}

--- a/Keysharp.Core/Core/Gui/WindowX.cs
+++ b/Keysharp.Core/Core/Gui/WindowX.cs
@@ -915,7 +915,7 @@ namespace Keysharp.Core
 			var rh = 30;
 			var ellipse = false;
 			var wind = false;
-			var points = new List<Point>(16);
+			var points = new List<POINT>(16);
 
 			foreach (Range r in opts.AsSpan().SplitAny(SpaceTabSv))
 			{
@@ -943,7 +943,7 @@ namespace Keysharp.Core
 					var vals = Conversions.ParseRange(splits);
 
 					if (vals.Count > 1)
-						points.Add(new Point(vals[0], vals[1]));
+						points.Add(new POINT(vals[0], vals[1]));
 				}
 			}
 
@@ -970,7 +970,7 @@ namespace Keysharp.Core
 					hrgn = WindowsAPI.CreateRectRgn(points[0].X, points[0].Y, w, h);
 			}
 			else
-				hrgn = WindowsAPI.CreatePolygonRgn(points.Select(p => new POINT { x = p.X, y = p.Y }).ToArray(), points.Count, wind ? WindowsAPI.WINDING : WindowsAPI.ALTERNATE);
+				hrgn = WindowsAPI.CreatePolygonRgn(points.Select(p => new POINT { X = p.X, Y = p.Y }).ToArray(), points.Count, wind ? WindowsAPI.WINDING : WindowsAPI.ALTERNATE);
 
 			if (hrgn != 0)
 			{

--- a/Keysharp.Core/Core/Ini.cs
+++ b/Keysharp.Core/Core/Ini.cs
@@ -128,16 +128,16 @@
 				if (!hasSec)
 					return Errors.OSErrorOccurred("", "Section name required when reading a single key.");
 
-				var sb = new StringBuilder((int)BUF_SIZE);
+				var chars = new char[BUF_SIZE];
 				// lpAppName = section (no brackets), wParam default = def
-				read = WindowsAPI.GetPrivateProfileString(s, k, def, sb, BUF_SIZE, file);
+				read = WindowsAPI.GetPrivateProfileString(s, k, def, chars, BUF_SIZE, file);
 				// error or not found?
 				var err = Marshal.GetLastWin32Error();
 
-				if (err != 0)
+				if (err != 0 || read < 0)
 					return @default != null ? def : Errors.OSErrorOccurred(new Win32Exception(err), $"Failed to read key '{k}' in section '{s}' from '{file}' (0x{err:X}).");
 
-				result = sb.ToString();
+				result = new string(chars, 0, (int)read);
 			}
 			else if (hasSec)
 			{

--- a/Keysharp.Core/Core/Keyboard.cs
+++ b/Keysharp.Core/Core/Keyboard.cs
@@ -99,7 +99,7 @@ namespace Keysharp.Core
 				return false;
 			}
 
-			var pt = new Point
+			var pt = new POINT
 			{
 				X = info.rcCaret.Left,
 				Y = info.rcCaret.Top

--- a/Keysharp.Core/Core/Loops.cs
+++ b/Keysharp.Core/Core/Loops.cs
@@ -614,9 +614,9 @@ namespace Keysharp.Core
 		internal static string GetShortPath(string filename)
 		{
 #if WINDOWS
-			var buffer = new StringBuilder(1024);
-			_ = WindowsAPI.GetShortPathName(filename, buffer, buffer.Capacity);
-			return buffer.ToString();
+			var buffer = new char[1024];
+			var len = WindowsAPI.GetShortPathName(filename, buffer, buffer.Length);
+			return new string(buffer, 0, len);
 #else
 			return DefaultObject;
 #endif

--- a/Keysharp.Core/Core/Map.cs
+++ b/Keysharp.Core/Core/Map.cs
@@ -222,7 +222,7 @@
 		public new object __New(params object[] args)
 		{
 			Init__Item();
-			Set(args);
+			_ = Set(args);
 			return DefaultObject;
 		}
 
@@ -484,7 +484,7 @@
 		/// </summary>
 		/// <param name="args">The values to set, arranged as key,value,key2,value2,etc...</param>
 		/// <exception cref="ValueError">A <see cref="ValueError"/> exception is thrown if values was not of a supported type.</exception>
-		public void Set(params object[] args)
+		public Map Set(params object[] args)
 		{
 			if (enumerableMap != null)
 				enumerableMap = null;
@@ -504,7 +504,7 @@
 					{
 						map = m.map;
 						caseSense = m.caseSense;
-						return;
+						return this;
 					}
 					else if (args[0] is Dictionary<object, object> dkt)
 					{
@@ -550,7 +550,7 @@
 					else
 					{
 						_ = Errors.ValueErrorOccurred($"Improper object type of {args[0].GetType()} passed to Map constructor.");
-						return;
+						return this;
 					}
 				}
 				else
@@ -564,6 +564,7 @@
 						Insert(args[i], args[i + 1]);
 				}
 			}
+			return this;
 		}
 		/// <summary>
 		/// Returns the string representation of all elements in the map.

--- a/Keysharp.Core/Core/Mouse.cs
+++ b/Keysharp.Core/Core/Mouse.cs
@@ -233,7 +233,7 @@ namespace Keysharp.Core
 			var aY = 0;
 			var script = Script.TheScript;
 			script.PlatformProvider.Manager.CoordToScreen(ref aX, ref aY, Core.CoordMode.Mouse);//Determine where 0,0 in window or client coordinates are on the screen.
-			var child = script.WindowProvider.Manager.WindowFromPoint(pos);
+			var child = script.WindowProvider.Manager.WindowFromPoint(new POINT(pos));
 			outputVarX = (long)(pos.X - aX);//Convert the mouse position in screen coordinates to window coordinates.
 			outputVarY = (long)(pos.Y - aY);
 			outputVarWin = null;

--- a/Keysharp.Core/Core/Processes.cs
+++ b/Keysharp.Core/Core/Processes.cs
@@ -468,7 +468,7 @@ namespace Keysharp.Core
 		{
 			const int MAX_PATH = 1024;
 			result = DefaultErrorString;
-			var buf = new StringBuilder(MAX_PATH);
+			var buf = new char[MAX_PATH];
 			nint hProc = WindowsAPI.OpenProcess(ProcessAccessTypes.PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
 
 			if (hProc == 0)
@@ -476,12 +476,12 @@ namespace Keysharp.Core
 
 			try
 			{
-				uint len = WindowsAPI.GetProcessImageFileName(hProc, buf, (uint)buf.Capacity);
+				uint len = WindowsAPI.GetProcessImageFileName(hProc, buf, (uint)buf.Length);
 
 				if (len == 0)
 					return 0;
 
-				string path = buf.ToString(0, (int)len);
+				string path = new string(buf, 0, (int)len);
 
 				if (getNameOnly)
 				{
@@ -491,18 +491,18 @@ namespace Keysharp.Core
 				}
 
 				// convert device path (\Device\HarddiskVolumeX\...) to drive letter C:\…
-				var device = new StringBuilder(MAX_PATH);
+				var device = new char[MAX_PATH];
 				var logicalPath = path;
 
 				for (char drv = 'A'; drv <= 'Z'; drv++)
 				{
 					string drive = drv + ":";
-					uint rc = WindowsAPI.QueryDosDevice(drive, device, (uint)device.Capacity);
+					uint rc = WindowsAPI.QueryDosDevice(drive, device, (uint)device.Length);
 
 					if (rc == 0)
 						continue;
 
-					string devPath = device.ToString();
+					string devPath = new string(device, 0, (int)rc);
 
 					if (path.StartsWith(devPath + "\\", StringComparison.OrdinalIgnoreCase))
 					{

--- a/Keysharp.Core/Core/Types.cs
+++ b/Keysharp.Core/Core/Types.cs
@@ -38,7 +38,7 @@
 		public static long IsAlpha(object value, object locale = null)
 		{
 			var s = value.As();
-			Func<char, bool> predicate = locale != null && locale.As().Equals("locale", StringComparison.OrdinalIgnoreCase) ? char.IsLetterOrDigit : char.IsLetterOrDigit;
+			Func<char, bool> predicate = locale != null && locale.As().Equals("locale", StringComparison.OrdinalIgnoreCase) ? char.IsLetter : char.IsAsciiLetter;
 			return s?.Length == 0 || s.All(predicate) ? 1L : 0L;
 		}
 

--- a/Keysharp.Core/Linux/PlatformManager.cs
+++ b/Keysharp.Core/Linux/PlatformManager.cs
@@ -42,7 +42,7 @@ namespace Keysharp.Core.Linux
 		internal override nint GetKeyboardLayout(uint idThread)
 		=> throw new NotImplementedException();
 
-		internal override int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff, int cchBuff, uint wFlags, nint dwhkl)
+		internal override int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out] char[] pwszBuff, int cchBuff, uint wFlags, nint dwhkl)
 		=> throw new NotImplementedException();
 
 		internal override bool SetDllDirectory(string path)

--- a/Keysharp.Core/Windows/NAudio/NAudio.cs
+++ b/Keysharp.Core/Windows/NAudio/NAudio.cs
@@ -1448,13 +1448,13 @@ namespace Keysharp.Core.Windows
 		}
 	}
 
-	internal class PropVariantNative
+	internal partial class PropVariantNative
 	{
-		[DllImport("ole32.dll", CharSet = CharSet.Unicode)]
+		[DllImport(WindowsAPI.ole32)]
 		internal static extern int PropVariantClear(ref PropVariant pvar);
 
-		[DllImport("ole32.dll", CharSet = CharSet.Unicode)]
-		internal static extern int PropVariantClear(nint pvar);
+		[LibraryImport(WindowsAPI.ole32, EntryPoint = "PropVariantClear")]
+		internal static partial int PropVariantClear(nint pvar);
 	}
 
 	/// <summary>

--- a/Keysharp.Core/Windows/PlatformManager.cs
+++ b/Keysharp.Core/Windows/PlatformManager.cs
@@ -27,7 +27,7 @@ namespace Keysharp.Core.Windows
 
 		internal override bool SetDllDirectory(string path) => WindowsAPI.SetDllDirectory(path);
 
-		internal override int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, StringBuilder pwszBuff, int cchBuff, uint wFlags, nint dwhkl)
+		internal override int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out] char[] pwszBuff, int cchBuff, uint wFlags, nint dwhkl)
 		=> WindowsAPI.ToUnicodeEx(wVirtKey, wScanCode, lpKeyState, pwszBuff, cchBuff, wFlags, dwhkl);
 
 		internal override bool UnregisterHotKey(nint hWnd, uint id) => WindowsAPI.UnregisterHotKey(hWnd, id);

--- a/Keysharp.Core/Windows/WindowItem.cs
+++ b/Keysharp.Core/Windows/WindowItem.cs
@@ -676,9 +676,9 @@ namespace Keysharp.Core.Windows
 			SendMouseEvent((uint)MOUSEEVENTF.RIGHTUP, location);
 		}
 
-		internal override Point ClientToScreen()
+		internal override POINT ClientToScreen()
 		{
-			var pt = new Point();
+			var pt = new POINT();
 			_ = WindowsAPI.ClientToScreen(Handle, ref pt);
 #if DPI
 			var scale = 1.0 / Accessors.A_ScaledScreenDPI;

--- a/Keysharp.Core/Windows/WindowManager.cs
+++ b/Keysharp.Core/Windows/WindowManager.cs
@@ -60,6 +60,13 @@ namespace Keysharp.Core.Windows
 			if (criteria.IsEmpty)
 				return found;
 
+			if (criteria.ID != 0)
+			{
+				if (IsWindow(criteria.ID) && CreateWindow(criteria.ID) is WindowItemBase temp && temp.Equals(criteria))
+					return temp;
+				return null;
+			}
+
 			var mm = ThreadAccessors.A_TitleMatchMode;
 
 			if (mm < 4) //If the matching mode is not RegEx then try to take an optimized path

--- a/Keysharp.Core/Windows/WindowManager.cs
+++ b/Keysharp.Core/Windows/WindowManager.cs
@@ -159,7 +159,7 @@ namespace Keysharp.Core.Windows
 			WindowItemBase.DoWinDelay();
 		}
 
-		internal override WindowItemBase WindowFromPoint(Point location)
+		internal override WindowItemBase WindowFromPoint(POINT location)
 		{
 			var ctrl = WindowsAPI.WindowFromPoint(location);
 

--- a/Keysharp.Core/Windows/WindowsAPI.cs
+++ b/Keysharp.Core/Windows/WindowsAPI.cs
@@ -1,5 +1,7 @@
 ﻿#if WINDOWS
 
+using System.Runtime.InteropServices.Marshalling;
+
 namespace Keysharp.Core.Windows
 {
 	internal enum GetAncestorFlags
@@ -362,8 +364,11 @@ namespace Keysharp.Core.Windows
 	[StructLayout(LayoutKind.Sequential)]
 	internal struct POINT
 	{
-		internal int x;
-		internal int y;
+		internal int X;
+		internal int Y;
+
+		internal POINT(int x, int y) { X = x; Y = y; }
+		internal POINT(Point p) { X = p.X; Y = p.Y; }
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
@@ -463,7 +468,7 @@ namespace Keysharp.Core.Windows
 		SOUND = 0xFFFFFFF5,
 	}
 
-	public static class WindowsAPI
+	public static partial class WindowsAPI
 	{
 		// File / Device IO
 		internal const uint GENERICREAD = 0x80000000;
@@ -1167,8 +1172,8 @@ namespace Keysharp.Core.Windows
 		[DllImport(oleacc, CharSet = CharSet.Unicode)]
 		internal static extern int AccessibleObjectFromWindow(nint hwnd, uint id, ref Guid iid, [In, Out, MarshalAs(UnmanagedType.IUnknown)] ref object ppvObject);
 
-		[DllImport(oleaut, CharSet = CharSet.Unicode)]
-		internal static extern void SysFreeString(nint bstr);
+		[LibraryImport(oleaut, EntryPoint = "SysFreeString")]
+		internal static partial void SysFreeString(nint bstr);
 
 
 		//[DllImport(oleaut)]
@@ -1195,14 +1200,17 @@ namespace Keysharp.Core.Windows
 			return false;
 		}
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool PeekMessage(out Msg message, nint handle, uint filterMin, uint filterMax, uint flags);
+		[LibraryImport(user32, EntryPoint = "PeekMessageW", StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool PeekMessage(out Msg message, nint handle, uint filterMin, uint filterMax, uint flags);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool OpenClipboard(nint hWndNewOwner);
+		[LibraryImport(user32, EntryPoint = "OpenClipboard")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool OpenClipboard(nint hWndNewOwner);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool CloseClipboard();
+		[LibraryImport(user32, EntryPoint = "CloseClipboard")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool CloseClipboard();
 
 		internal static bool OpenClipboard(long ms)
 		{
@@ -1259,23 +1267,24 @@ namespace Keysharp.Core.Windows
 			return GetClipboardData((uint)format);
 		}
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern nint GlobalSize(nint handle);
+		[LibraryImport(kernel32, EntryPoint = "GlobalSize")]
+		internal static partial nint GlobalSize(nint handle);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern nint GlobalLock(nint hMem);
+		[LibraryImport(kernel32, EntryPoint = "GlobalLock")]
+		internal static partial nint GlobalLock(nint hMem);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool GlobalUnlock(nint hMem);
+		[LibraryImport(kernel32, EntryPoint = "GlobalUnlock")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool GlobalUnlock(nint hMem);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetClipboardData(uint uFormat);
+		[LibraryImport(user32, EntryPoint = "GetClipboardData")]
+		internal static partial nint GetClipboardData(uint uFormat);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint SetClipboardData(uint uFormat, nint hMem);
+		[LibraryImport(user32, EntryPoint = "SetClipboardData")]
+		internal static partial nint SetClipboardData(uint uFormat, nint hMem);
 
-		[DllImport(dwmapi, CharSet = CharSet.Unicode)]
-		internal static extern uint DwmGetWindowAttribute(nint hwnd, DWMWINDOWATTRIBUTE dwAttribute, ref int pvAttribute, int cbsize);
+		[LibraryImport(dwmapi, EntryPoint = "DwmGetWindowAttribute")]
+		internal static partial uint DwmGetWindowAttribute(nint hwnd, DWMWINDOWATTRIBUTE dwAttribute, ref int pvAttribute, int cbsize);
 
 		internal static bool IsWindowCloaked(nint hwnd)
 		{
@@ -1283,32 +1292,34 @@ namespace Keysharp.Core.Windows
 			return DwmGetWindowAttribute(hwnd, DWMWINDOWATTRIBUTE.DWMWA_CLOAKED, ref cloaked, 4) >= 0 && cloaked >= 0;
 		}
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetLastActivePopup(nint hWnd);
+		[LibraryImport(user32, EntryPoint = "GetLastActivePopup")]
+		internal static partial nint GetLastActivePopup(nint hWnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetShellWindow();
+		[LibraryImport(user32, EntryPoint = "GetShellWindow")]
+		internal static partial nint GetShellWindow();
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool BlockInput(bool fBlockIt);
+		[LibraryImport(user32, EntryPoint = "BlockInput")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool BlockInput([MarshalAs(UnmanagedType.Bool)] bool fBlockIt);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint CallNextHookEx(nint hhk, int nCode, nint wParam, ref EventMsg lParam);
+		[LibraryImport(user32, EntryPoint = "CallNextHookEx")]
+		internal static partial nint CallNextHookEx(nint hhk, int nCode, nint wParam, ref EventMsg lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint CallNextHookEx(nint hhk, int nCode, nint wParam, ref KBDLLHOOKSTRUCT lParam);
+		[LibraryImport(user32, EntryPoint = "CallNextHookEx")]
+		internal static partial nint CallNextHookEx(nint hhk, int nCode, nint wParam, ref KBDLLHOOKSTRUCT lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint CallNextHookEx(nint hhk, int nCode, nint wParam, ref MSDLLHOOKSTRUCT lParam);
+		[LibraryImport(user32, EntryPoint = "CallNextHookEx")]
+		internal static partial nint CallNextHookEx(nint hhk, int nCode, nint wParam, ref MSDLLHOOKSTRUCT lParam);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool CloseHandle(nint hObject);
+		[LibraryImport(kernel32, EntryPoint = "CloseHandle")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool CloseHandle(nint hObject);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int CloseWindow(nint hWnd);
+		[LibraryImport(user32, EntryPoint = "CloseWindow")]
+		internal static partial int CloseWindow(nint hWnd);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
-		internal static extern nint CreateFile(string fileName,
+		[LibraryImport(kernel32, EntryPoint = "CreateFileW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial nint CreateFile(string fileName,
 											   uint desiredAccess,
 											   uint shareMode,
 											   nint attributes,
@@ -1316,8 +1327,9 @@ namespace Keysharp.Core.Windows
 											   uint flagsAndAttributes,
 											   nint templateFile);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool DestroyWindow(nint hwnd);
+		[LibraryImport(user32, EntryPoint = "DestroyWindow")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool DestroyWindow(nint hwnd);
 
 		[DllImport(kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
 		internal static extern bool DeviceIoControl(
@@ -1330,8 +1342,9 @@ namespace Keysharp.Core.Windows
 			ref int pBytesReturned,
 			[In] ref NativeOverlapped lpOverlapped);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool DestroyIcon(nint handle);
+		[LibraryImport(user32, EntryPoint = "DestroyIcon")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool DestroyIcon(nint handle);
 
 		//[DllImport(kernel32, SetLastError = true)]
 		//internal static extern bool DeviceIoControl(nint driveHandle,
@@ -1345,52 +1358,59 @@ namespace Keysharp.Core.Windows
 		[DllImport(winmm, CharSet = CharSet.Unicode)]
 		internal static extern int mciSendString(string command, StringBuilder buffer, int bufferSize, nint hwndCallback);
 
-		[DllImport(winmm, CharSet = CharSet.Unicode)]
-		internal static extern int joyGetPosEx(int uJoyID, ref JOYINFOEX pji);
+		[LibraryImport(winmm, EntryPoint = "joyGetPosEx")]
+		internal static partial int joyGetPosEx(int uJoyID, ref JOYINFOEX pji);
 
 		[DllImport(winmm, CharSet = CharSet.Unicode)]
 		internal static extern int joyGetDevCaps(nint id, ref JOYCAPS lpCaps, uint uSize);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool SetProcessDPIAware();
-
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool IsHungAppWindow(nint hWnd);
-
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool EnableWindow(nint hWnd, bool bEnable);
-
-		[DllImport(user32, CharSet = CharSet.Unicode)]
+		[LibraryImport(user32, EntryPoint = "SetProcessDPIAware")]
 		[return: MarshalAs(UnmanagedType.Bool)]
-		internal static extern bool EnumChildWindows(nint hwndParent, _EnumWindowsProc lpEnumFunc, object lParam);
+		internal static partial bool SetProcessDPIAware();
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int EnumWindows(_EnumWindowsProc lpEnumFunc, int lParam);
+		[LibraryImport(user32, EntryPoint = "IsHungAppWindow")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool IsHungAppWindow(nint hWnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool ExitWindowsEx(uint uFlags, uint dwReason);
+		[LibraryImport(user32, EntryPoint = "EnableWindow")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool EnableWindow(nint hWnd, [MarshalAs(UnmanagedType.Bool)] bool bEnable);
 
-		[DllImport(shell32, CharSet = CharSet.Unicode)]
-		internal static extern nint ExtractIcon(nint hInst, string lpszExeFileName, int nIconIndex);
+		[LibraryImport(user32, EntryPoint = "EnumChildWindows")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool EnumChildWindows(nint hwndParent, _EnumWindowsProc lpEnumFunc, nint lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
+		[LibraryImport(user32, EntryPoint = "EnumWindows")]
+		internal static partial int EnumWindows(_EnumWindowsProc lpEnumFunc, nint lParam);
+
+		[LibraryImport(user32, EntryPoint = "ExitWindowsEx")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool ExitWindowsEx(uint uFlags, uint dwReason);
+
+		[LibraryImport(shell32, EntryPoint = "ExtractIconW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial nint ExtractIcon(nint hInst, string lpszExeFileName, int nIconIndex);
+
+		[LibraryImport(user32, EntryPoint = "FindWindowW", StringMarshalling = StringMarshalling.Utf16)]
 		[PublicForTestOnly]
-		public static extern nint FindWindow(string className, string windowName);
+		public static partial nint FindWindow(string className, string windowName);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint FindWindowEx(nint parentHandle, nint childAfter, string className, string windowTitle);
+		[LibraryImport(user32, EntryPoint = "FindWindowExW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial nint FindWindowEx(nint parentHandle, nint childAfter, string className, string windowTitle);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool FlashWindow(nint hWnd, bool bInvert);
+		[LibraryImport(user32, EntryPoint = "FlashWindow")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool FlashWindow(nint hWnd, [MarshalAs(UnmanagedType.Bool)] bool bInvert);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool FreeLibrary(nint hModule);
+		[LibraryImport(kernel32, EntryPoint = "FreeLibrary")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool FreeLibrary(nint hModule);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern uint GetCurrentThreadId();
+		[LibraryImport(kernel32, EntryPoint = "GetCurrentThreadId")]
+		internal static partial uint GetCurrentThreadId();
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
+		[LibraryImport(user32, EntryPoint = "AttachThreadInput")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool AttachThreadInput(uint idAttach, uint idAttachTo, [MarshalAs(UnmanagedType.Bool)] bool fAttach);
 
 		internal static (bool, uint) AttachThreadInput(nint targetWindow, bool setActive)
 		{
@@ -1437,109 +1457,116 @@ namespace Keysharp.Core.Windows
 			return mem;
 		}
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetActiveWindow(nint hWnd);
+		[LibraryImport(user32, EntryPoint = "GetActiveWindow")]
+		internal static partial nint GetActiveWindow(nint hWnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetActiveWindow();
+		[LibraryImport(user32, EntryPoint = "GetActiveWindow")]
+		internal static partial nint GetActiveWindow();
 
-		[DllImport(user32, CharSet = CharSet.Unicode, ExactSpelling = true)]
-		internal static extern nint GetAncestor(nint hWnd, gaFlags gaFlags);
+		[LibraryImport(user32, EntryPoint = "GetAncestor")]
+		internal static partial nint GetAncestor(nint hWnd, gaFlags gaFlags);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int GetClassName(nint hWnd, StringBuilder lpClassName, int nMaxCount);
+		[LibraryImport(user32, EntryPoint = "GetClassNameW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static unsafe partial int GetClassName(nint hWnd, [Out] char[] lpClassName, int nMaxCount);
 
 		internal static string GetClassName(nint hwnd)
 		{
-			var buf = new StringBuilder(64);
-			_ = GetClassName(hwnd, buf, buf.Capacity);
-			return buf.ToString();
+			var buffer = new char[256];
+			int len = GetClassName(hwnd, buffer, buffer.Length);
+			return new string(buffer, 0, len);
 		}
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool GetCursorPos(out Point lpPoint);
+		[LibraryImport(user32, EntryPoint = "GetCursorPos")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool GetCursorPos(out POINT lpPoint);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
+		[LibraryImport(user32, EntryPoint = "GetDesktopWindow")]
 		[PublicForTestOnly]
-		public static extern long GetDesktopWindow();
+		public static partial long GetDesktopWindow();
 
-		[DllImport(version, CharSet = CharSet.Unicode)]
-		internal static extern bool GetFileVersionInfo(string sFileName, int handle, int size, byte[] infoBuffer);
+		[LibraryImport(version, EntryPoint = "GetFileVersionInfoW", StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool GetFileVersionInfo(string sFileName, int handle, int size, byte[] infoBuffer);
 
-		[DllImport(version, CharSet = CharSet.Unicode)]
-		internal static extern int GetFileVersionInfoSize(string sFileName, out int handle);
+		[LibraryImport(version, EntryPoint = "GetFileVersionInfoSizeW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial int GetFileVersionInfoSize(string sFileName, out int handle);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetFocus();
+		[LibraryImport(user32, EntryPoint = "GetFocus")]
+		internal static partial nint GetFocus();
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetParent(nint hWnd);
+		[LibraryImport(user32, EntryPoint = "GetParent")]
+		internal static partial nint GetParent(nint hWnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetForegroundWindow();
+		[LibraryImport(user32, EntryPoint = "GetForegroundWindow")]
+		internal static partial nint GetForegroundWindow();
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool GetGUIThreadInfo(uint idThread, out GUITHREADINFO lpgui);
+		[LibraryImport(user32, EntryPoint = "GetGUIThreadInfo")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool GetGUIThreadInfo(uint idThread, out GUITHREADINFO lpgui);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int ActivateKeyboardLayout(nint hkl, uint Flags);
+		[LibraryImport(user32, EntryPoint = "ActivateKeyboardLayout")]
+		internal static partial int ActivateKeyboardLayout(nint hkl, uint Flags);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetKeyboardLayout(uint idThread);
+		[LibraryImport(user32, EntryPoint = "GetKeyboardLayout")]
+		internal static partial nint GetKeyboardLayout(uint idThread);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool GetKeyboardLayoutName([Out] StringBuilder pwszKLID);
+		[LibraryImport(user32, EntryPoint = "GetKeyboardLayoutNameW", StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool GetKeyboardLayoutName([Out] char[] pwszKLID);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool GetKeyboardState(byte[] lpKeyState);
+		[LibraryImport(user32, EntryPoint = "GetKeyboardState")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool GetKeyboardState(byte[] lpKeyState);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool SetKeyboardState(byte[] lpKeyState);
+		[LibraryImport(user32, EntryPoint = "SetKeyboardState")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool SetKeyboardState(byte[] lpKeyState);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern short GetKeyState(int nVirtKey);
+		[LibraryImport(user32, EntryPoint = "GetKeyState")]
+		internal static partial short GetKeyState(int nVirtKey);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern short GetAsyncKeyState(int nVirtKey);
+		[LibraryImport(user32, EntryPoint = "GetAsyncKeyState")]
+		internal static partial short GetAsyncKeyState(int nVirtKey);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, uint dwExtraInfo);
+		[LibraryImport(user32, EntryPoint = "keybd_event")]
+		internal static partial void keybd_event(byte bVk, byte bScan, uint dwFlags, uint dwExtraInfo);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetMenu(nint hWnd);
+		[LibraryImport(user32, EntryPoint = "GetMenu")]
+		internal static partial nint GetMenu(nint hWnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetSystemMenu(nint hWnd, bool revert);
+		[LibraryImport(user32, EntryPoint = "GetSystemMenu")]
+		internal static partial nint GetSystemMenu(nint hWnd, [MarshalAs(UnmanagedType.Bool)] bool revert);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int GetMenuItemCount(nint hMenu);
+		[LibraryImport(user32, EntryPoint = "GetMenuItemCount")]
+		internal static partial int GetMenuItemCount(nint hMenu);
 
 		[DllImport(user32, CharSet = CharSet.Unicode)]
 		internal static extern int GetMenuString(nint hMenu, uint uIDItem, [Out] StringBuilder lpString, int nMaxCount, uint uFlag);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern unsafe bool IsDialogMessage(nint hDlg, Msg lpMsg);
+		[LibraryImport(user32, EntryPoint = "IsDialogMessageW")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool IsDialogMessage(nint hDlg, Msg lpMsg);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int GetMessage(out Msg lpMsg, nint hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
+		[LibraryImport(user32, EntryPoint = "GetMessageW")]
+		internal static partial int GetMessage(out Msg lpMsg, nint hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetMessageExtraInfo();
+		[LibraryImport(user32, EntryPoint = "GetMessageExtraInfo")]
+		internal static partial nint GetMessageExtraInfo();
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern int GetModuleHandleEx(uint dwFlags, string lpModuleName, out nint phModule);
+		[LibraryImport(kernel32, EntryPoint = "GetModuleHandleExW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial int GetModuleHandleEx(uint dwFlags, string lpModuleName, out nint phModule);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetModuleHandle(string lpModuleName);
+		[LibraryImport(kernel32, EntryPoint = "GetModuleHandleW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial nint GetModuleHandle(string lpModuleName);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
-		internal static extern uint GetPrivateProfileString(string lpAppName, string lpKeyName, string lpDefault, StringBuilder lpReturnedString, uint nSize, string lpFileName);
+		[LibraryImport(kernel32, EntryPoint = "GetPrivateProfileStringW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial uint GetPrivateProfileString(string lpAppName, string lpKeyName, string lpDefault, [Out] char[] lpReturnedString, uint nSize, string lpFileName);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
-		internal static extern uint GetPrivateProfileSection(string lpAppName, [Out] char[] lpszReturnBuffer, uint nSize, string lpFileName);
+		[LibraryImport(kernel32, EntryPoint = "GetPrivateProfileSectionW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial uint GetPrivateProfileSection(string lpAppName, [Out] char[] lpszReturnBuffer, uint nSize, string lpFileName);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
-		internal static extern uint GetPrivateProfileSectionNames([Out] char[] lpszReturnBuffer, uint nSize, string lpFileName);
+		[LibraryImport(kernel32, EntryPoint = "GetPrivateProfileSectionNamesW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial uint GetPrivateProfileSectionNames([Out] char[] lpszReturnBuffer, uint nSize, string lpFileName);
 
 		/// <summary>
 		/// Set this to use ExactSpelling since GetProcAddress() only is available in ANSI.
@@ -1547,55 +1574,61 @@ namespace Keysharp.Core.Windows
 		/// <param name="hModule"></param>
 		/// <param name="procName"></param>
 		/// <returns></returns>
-		[DllImport(kernel32, CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
-		internal static extern nint GetProcAddress(nint hModule, string procName);
+		[LibraryImport(kernel32, EntryPoint = "GetProcAddress", SetLastError = true)]
+		internal static partial nint GetProcAddress(nint hModule, [MarshalAs(UnmanagedType.LPStr)] string procName);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetSubMenu(nint hMenu, int nPos);
+		[LibraryImport(user32, EntryPoint = "GetSubMenu")]
+		internal static partial nint GetSubMenu(nint hMenu, int nPos);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern uint GetMenuItemID(nint hMenu, int nPos);
+		[LibraryImport(user32, EntryPoint = "GetMenuItemID")]
+		internal static partial uint GetMenuItemID(nint hMenu, int nPos);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern void SetLastError(uint dwErrCode);
+		[LibraryImport(kernel32, EntryPoint = "SetLastError")]
+		internal static partial void SetLastError(uint dwErrCode);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern uint GetLastError();
+		[LibraryImport(kernel32, EntryPoint = "GetLastError")]
+		internal static partial uint GetLastError();
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int GetDlgCtrlID(nint hwndCtl);
+		[LibraryImport(user32, EntryPoint = "GetDlgCtrlID")]
+		internal static partial int GetDlgCtrlID(nint hwndCtl);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetWindow(nint hWnd, uint uCmd);
+		[LibraryImport(user32, EntryPoint = "GetWindow")]
+		internal static partial nint GetWindow(nint hWnd, uint uCmd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
-
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool GetLayeredWindowAttributes(nint hwnd, out uint crKey, out byte bAlpha, out uint dwFlags);
-
-		[DllImport(user32, CharSet = CharSet.Unicode)]
+		[LibraryImport(user32, EntryPoint = "GetLastInputInfo")]
 		[return: MarshalAs(UnmanagedType.Bool)]
-		internal static extern bool GetWindowPlacement(nint hWnd, out WINDOWPLACEMENT lpwndpl);
+		internal static partial bool GetLastInputInfo(ref LASTINPUTINFO plii);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
+		[LibraryImport(user32, EntryPoint = "GetLayeredWindowAttributes")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool GetLayeredWindowAttributes(nint hwnd, out uint crKey, out byte bAlpha, out uint dwFlags);
+
+		[LibraryImport(user32, EntryPoint = "GetWindowPlacement")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool GetWindowPlacement(nint hWnd, out WINDOWPLACEMENT lpwndpl);
+
+		[LibraryImport(user32, EntryPoint = "GetWindowRect")]
+		[return: MarshalAs(UnmanagedType.Bool)]
 		[PublicForTestOnly]
-		public static extern bool GetWindowRect(nint hWnd, out RECT lpRect);
+		public static partial bool GetWindowRect(nint hWnd, out RECT lpRect);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool GetClientRect(nint hWnd, out RECT lpRect);
+		[LibraryImport(user32, EntryPoint = "GetClientRect")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool GetClientRect(nint hWnd, out RECT lpRect);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int MapWindowPoints(nint hWndFrom, nint hWndTo, [In, Out] ref RECT rect, [MarshalAs(UnmanagedType.U4)] int cPoints);
+		[LibraryImport(user32, EntryPoint = "MapWindowPoints")]
+		internal static partial int MapWindowPoints(nint hWndFrom, nint hWndTo, ref RECT rect, uint cPoints);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool ClientToScreen(nint hWnd, ref Point lpPoint);
+		[LibraryImport(user32, EntryPoint = "ClientToScreen")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool ClientToScreen(nint hWnd, ref POINT lpPoint);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool ScreenToClient(nint hWnd, ref Point lpPoint);
+		[LibraryImport(user32, EntryPoint = "ScreenToClient")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool ScreenToClient(nint hWnd, ref POINT lpPoint);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int GetWindowText(nint hWnd, StringBuilder lpString, int nMaxCount);
+		[LibraryImport(user32, EntryPoint = "GetWindowTextW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial int GetWindowText(nint hWnd, [Out] char[] lpString, int nMaxCount);
 
 		//void CoordToScreen(POINT &aPoint, int aWhichMode)
 		//// For convenience. See function above for comments.
@@ -1603,20 +1636,21 @@ namespace Keysharp.Core.Windows
 		//  CoordToScreen((int &)aPoint.x, (int &)aPoint.y, aWhichMode);
 		//}
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern void mouse_event(uint dwFlags, int dx, int dy, uint dwData, nint dwExtraInfo);
+		[LibraryImport(user32, EntryPoint = "mouse_event")]
+		internal static partial void mouse_event(uint dwFlags, int dx, int dy, uint dwData, nint dwExtraInfo);
 
 		/// <summary>
 		/// See http://msdn.microsoft.com/en-us/library/ms632599%28VS.85%29.aspx#message_only
 		/// </summary>
 		/// <param name="hwnd"></param>
 		/// <returns></returns>
-		[DllImport(user32, CharSet = CharSet.Unicode)]
+		[LibraryImport(user32, EntryPoint = "AddClipboardFormatListener")]
 		[return: MarshalAs(UnmanagedType.Bool)]
-		internal static extern bool AddClipboardFormatListener(nint hwnd);
+		internal static partial bool AddClipboardFormatListener(nint hwnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool RemoveClipboardFormatListener(nint hwnd);
+		[LibraryImport(user32, EntryPoint = "RemoveClipboardFormatListener")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool RemoveClipboardFormatListener(nint hwnd);
 
 		internal static string GetWindowText(nint hwnd)
 		{
@@ -1625,104 +1659,118 @@ namespace Keysharp.Core.Windows
 			if (textLength == 0)
 				return string.Empty;
 
-			StringBuilder outText = new StringBuilder(textLength + 1);
-			int a = GetWindowText(hwnd, outText, outText.Capacity);
-			return outText.ToString();
+			char[] outText = new char[textLength + 1];
+			int a = GetWindowText(hwnd, outText, outText.Length);
+			return new string(outText, 0, a);
 		}
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int GetWindowTextLength(nint hWnd);
+		[LibraryImport(user32, EntryPoint = "GetWindowTextLengthW")]
+		internal static partial int GetWindowTextLength(nint hWnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern uint GetWindowThreadProcessId(nint hWnd, out uint lpdwProcessId);
+		[LibraryImport(user32, EntryPoint = "GetWindowThreadProcessId")]
+		internal static partial uint GetWindowThreadProcessId(nint hWnd, out uint lpdwProcessId);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool InvalidateRect(nint hWnd, nint lpRect, bool bErase);
-
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool IsWindow(nint hWnd);
-
-		[DllImport(user32, CharSet = CharSet.Unicode)]
+		[LibraryImport(user32, EntryPoint = "InvalidateRect")]
 		[return: MarshalAs(UnmanagedType.Bool)]
-		internal static extern bool IsWindowEnabled(nint hWnd);
+		internal static partial bool InvalidateRect(nint hWnd, nint lpRect, [MarshalAs(UnmanagedType.Bool)] bool bErase);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool IsWindowVisible(nint hWnd);
+		[LibraryImport(user32, EntryPoint = "IsWindow")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool IsWindow(nint hWnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool IsChild(nint hWndParent, nint hWnd);
+		[LibraryImport(user32, EntryPoint = "IsWindowEnabled")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool IsWindowEnabled(nint hWnd);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool SetDllDirectory(string lpPathName);
+		[LibraryImport(user32, EntryPoint = "IsWindowVisible")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool IsWindowVisible(nint hWnd);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern nint LoadLibrary(string lpFileName);
+		[LibraryImport(user32, EntryPoint = "IsChild")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool IsChild(nint hWndParent, nint hWnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern short VkKeyScanEx(char ch, nint dwhkl);
+		[LibraryImport(kernel32, EntryPoint = "SetDllDirectoryW", StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool SetDllDirectory(string lpPathName);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern uint MapVirtualKey(uint uCode, uint uMapType);
+		[LibraryImport(kernel32, EntryPoint = "LoadLibraryW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial nint LoadLibrary(string lpFileName);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern uint MapVirtualKeyEx(uint uCode, uint uMapType, nint dwhkl);
+		[LibraryImport(user32, EntryPoint = "VkKeyScanExW")]
+		internal static partial short VkKeyScanEx([MarshalAs(UnmanagedType.U2)] char ch, nint dwhkl);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool MoveWindow(nint hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
+		[LibraryImport(user32, EntryPoint = "MapVirtualKeyW")]
+		internal static partial uint MapVirtualKey(uint uCode, uint uMapType);
+
+		[LibraryImport(user32, EntryPoint = "MapVirtualKeyExW")]
+		internal static partial uint MapVirtualKeyEx(uint uCode, uint uMapType, nint dwhkl);
+
+		[LibraryImport(user32, EntryPoint = "MoveWindow")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool MoveWindow(nint hWnd, int X, int Y, int nWidth, int nHeight, [MarshalAs(UnmanagedType.Bool)] bool bRepaint);
 
 		//[DllImport(kernel32, CharSet = CharSet.Unicode)]
 		//internal static extern nint OpenProcess(uint dwDesiredAccess, bool bInheritHandle, uint dwProcessId);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern void OutputDebugString(string lpOutputString);
+		[LibraryImport(kernel32, EntryPoint = "OutputDebugStringW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial void OutputDebugString(string lpOutputString);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern void PostQuitMessage(int nExitCode);
+		[LibraryImport(user32, EntryPoint = "PostQuitMessage")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial void PostQuitMessage(int nExitCode);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool PostThreadMessage(uint threadId, uint msg, nint wParam, nint lParam);
+		[LibraryImport(user32, EntryPoint = "PostThreadMessageW")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool PostThreadMessage(uint threadId, uint msg, nint wParam, nint lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool PostMessage(nint hWnd, uint msg, nint wParam, nint lParam);
+		[LibraryImport(user32, EntryPoint = "PostMessageW", StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool PostMessage(nint hWnd, uint msg, nint wParam, nint lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool PostMessage(nint hWnd, uint msg, uint wParam, uint lParam);
+		[LibraryImport(user32, EntryPoint = "PostMessageW")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool PostMessage(nint hWnd, uint msg, uint wParam, uint lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool PostMessage(nint hWnd, uint msg, string wParam, nint lParam);
+		[LibraryImport(user32, EntryPoint = "PostMessageW", StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool PostMessage(nint hWnd, uint msg, string wParam, nint lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern long GetMessageTime();
+		[LibraryImport(user32, EntryPoint = "GetMessageTime")]
+		internal static partial long GetMessageTime();
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint RealChildWindowFromPoint(nint hwndParent, Point ptParentClientCoords);
+		[LibraryImport(user32, EntryPoint = "RealChildWindowFromPoint")]
+		internal static partial nint RealChildWindowFromPoint(nint hwndParent, POINT ptParentClientCoords);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+		[LibraryImport(user32, EntryPoint = "SendInput")]
+		internal static partial uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern uint SendMessage(nint hWnd, uint msg, uint wParam, uint lParam);
+		[LibraryImport(user32, EntryPoint = "SendMessageW")]
+		internal static partial uint SendMessage(nint hWnd, uint msg, uint wParam, uint lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint SendMessage(nint hWnd, uint msg, nint wParam, nint lParam);
+		[LibraryImport(user32, EntryPoint = "SendMessageW")]
+		internal static partial nint SendMessage(nint hWnd, uint msg, nint wParam, nint lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint SendMessage(nint hWnd, uint msg, int wParam, int[] lParam);
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint SendMessage(nint hWnd, uint msg, int wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam);
+		[LibraryImport(user32, EntryPoint = "SendMessageW")]
+		internal static partial nint SendMessage(nint hWnd, uint msg, int wParam, int[] lParam);
+
+		[LibraryImport(user32, EntryPoint = "SendMessageW")]
+		internal static partial nint SendMessage(nint hWnd, uint msg, int wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam);
 
 		[DllImport(user32, CharSet = CharSet.Unicode)]
 		internal static extern nint SendLVColMessage(nint hWnd, uint msg, uint wParam, ref LV_COLUMN lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool IsIconic(nint Hwnd);
+		[LibraryImport(user32, EntryPoint = "IsIconic")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool IsIconic(nint Hwnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool IsZoomed(nint hWnd);
+		[LibraryImport(user32, EntryPoint = "IsZoomed")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool IsZoomed(nint hWnd);
 
-		[DllImport(shell32, CharSet = CharSet.Unicode, SetLastError = true)]
-		internal static extern int SHGetKnownFolderPath(
-			[MarshalAs(UnmanagedType.LPStruct)] Guid rfid,
+		[LibraryImport(shell32, EntryPoint = "SHGetKnownFolderPath", SetLastError = true)]
+		internal static partial int SHGetKnownFolderPath(
+			Guid rfid,
 			uint dwFlags,
 			nint hToken,
 			out nint pszPath);
@@ -1782,18 +1830,9 @@ namespace Keysharp.Core.Windows
 		[DllImport(user32, CharSet = CharSet.Unicode)]
 		internal static extern int PostMessage(nint hWnd, uint Msg, nint wParam, ref COPYDATASTRUCT lParam);
 
-		[DllImport(user32, SetLastError = true, CharSet = CharSet.Unicode)]
-		internal static extern long SendMessageTimeout(
-			nint hWnd,
-			uint Msg,
-			object wParam,
-			string lParam,
-			SendMessageTimeoutFlags flags,
-			uint timeout,
-			out nint result);
 
-		[DllImport(user32, SetLastError = true, CharSet = CharSet.Unicode)]
-		internal static extern long SendMessageTimeout(
+		[LibraryImport(user32, EntryPoint = "SendMessageTimeoutW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial long SendMessageTimeout(
 			nint hWnd,
 			uint Msg,
 			nint wParam,
@@ -1802,8 +1841,8 @@ namespace Keysharp.Core.Windows
 			uint timeout,
 			out nint result);
 
-		[DllImport(user32, SetLastError = true, CharSet = CharSet.Unicode)]
-		internal static extern long SendMessageTimeout(
+		[LibraryImport(user32, EntryPoint = "SendMessageTimeoutW", SetLastError = true)]
+		internal static partial long SendMessageTimeout(
 			nint hWnd,
 			uint Msg,
 			ref uint wParam,
@@ -1812,8 +1851,8 @@ namespace Keysharp.Core.Windows
 			uint timeout,
 			out nint result);
 
-		[DllImport(user32, SetLastError = true, CharSet = CharSet.Unicode)]
-		internal static extern long SendMessageTimeout(
+		[LibraryImport(user32, EntryPoint = "SendMessageTimeoutW", SetLastError = true)]
+		internal static partial long SendMessageTimeout(
 			nint hWnd,
 			uint Msg,
 			ref nint wParam,
@@ -1822,8 +1861,8 @@ namespace Keysharp.Core.Windows
 			uint timeout,
 			out nint result);
 
-		[DllImport(user32, SetLastError = true, CharSet = CharSet.Unicode)]
-		internal static extern long SendMessageTimeout(
+		[LibraryImport(user32, EntryPoint = "SendMessageTimeoutW", SetLastError = true)]
+		internal static partial long SendMessageTimeout(
 			nint hWnd,
 			uint Msg,
 			nint wParam,
@@ -1832,12 +1871,12 @@ namespace Keysharp.Core.Windows
 			uint timeout,
 			out nint result);
 
-		[DllImport(user32, SetLastError = true, CharSet = CharSet.Unicode)]
-		internal static extern int SendMessageTimeout(
+		[LibraryImport(user32, EntryPoint = "SendMessageTimeoutW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial long SendMessageTimeout(
 			nint hWnd,
 			uint Msg,
 			nint wParam,
-			StringBuilder lParam,
+			char[] lParam,
 			SendMessageTimeoutFlags flags,
 			uint timeout,
 			out nint result);
@@ -1857,104 +1896,117 @@ namespace Keysharp.Core.Windows
 			nint lpcbSecurityDescriptor,
 			out long lpftLastWriteTime);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern int GetShortPathName(string longPath, StringBuilder shortPath, int bufSize);
+		[LibraryImport(kernel32, EntryPoint = "GetShortPathNameW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial int GetShortPathName(string longPath, [Out] char[] shortPath, int bufSize);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int SetActiveWindow(nint handle);
+		[LibraryImport(user32, EntryPoint = "SetActiveWindow")]
+		internal static partial int SetActiveWindow(nint handle);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool BringWindowToTop(nint hWnd);
+		[LibraryImport(user32, EntryPoint = "BringWindowToTop")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool BringWindowToTop(nint hWnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint SetFocus(nint hWnd);
+		[LibraryImport(user32, EntryPoint = "SetFocus")]
+		internal static partial nint SetFocus(nint hWnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
+		[LibraryImport(user32, EntryPoint = "SetForegroundWindow")]
+		[return: MarshalAs(UnmanagedType.Bool)]
 		[PublicForTestOnly]
-		public static extern bool SetForegroundWindow(nint hWnd);
+		public static partial bool SetForegroundWindow(nint hWnd);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool SetLayeredWindowAttributes(nint hwnd, uint crKey, byte bAlpha, uint dwFlags);
+		[LibraryImport(user32, EntryPoint = "SetLayeredWindowAttributes")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool SetLayeredWindowAttributes(nint hwnd, uint crKey, byte bAlpha, uint dwFlags);
 
 		//[DllImport(user32, CharSet = CharSet.Unicode)]
 		//internal static extern int SetWindowLong(nint hWnd, int nIndex, int dwNewLong);
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetWindowLongPtr(nint hWnd, int nIndex);
+		[LibraryImport(user32, EntryPoint = "GetWindowLongPtrW")]
+		internal static partial nint GetWindowLongPtr(nint hWnd, int nIndex);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint SetWindowLongPtr(nint hWnd, int nIndex, nint dwNewLong);
+		[LibraryImport(user32, EntryPoint = "SetWindowLongPtrW")]
+		internal static partial nint SetWindowLongPtr(nint hWnd, int nIndex, nint dwNewLong);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
+		[LibraryImport(user32, EntryPoint = "SetWindowPos")]
 		[return: MarshalAs(UnmanagedType.Bool)]
-		internal static extern bool SetWindowPos(nint hWnd, nint hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+		internal static partial bool SetWindowPos(nint hWnd, nint hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, nint hMod, uint dwThreadId);
+		[LibraryImport(user32, EntryPoint = "SetWindowsHookExW")]
+		internal static partial nint SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, nint hMod, uint dwThreadId);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint SetWindowsHookEx(int idHook, LowLevelMouseProc lpfn, nint hMod, uint dwThreadId);
+		[LibraryImport(user32, EntryPoint = "SetWindowsHookExW")]
+		internal static partial nint SetWindowsHookEx(int idHook, LowLevelMouseProc lpfn, nint hMod, uint dwThreadId);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint SetWindowsHookEx(int idHook, PlaybackProc lpfn, nint hMod, uint dwThreadId);
+		[LibraryImport(user32, EntryPoint = "SetWindowsHookExW")]
+		internal static partial nint SetWindowsHookEx(int idHook, PlaybackProc lpfn, nint hMod, uint dwThreadId);
 
 		//[DllImport(user32, CharSet = CharSet.Unicode)]
 		//internal static extern nint CallNextHookEx(nint hhk, int nCode, int wParam, [In] KBDLLHOOKSTRUCT lParam);
 		//[DllImport(user32, CharSet = CharSet.Unicode)]
 		//internal static extern nint CallNextHookEx(nint hhk, int nCode, int wParam, [In] MSDLLHOOKSTRUCT lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool SetWindowText(nint hWnd, string lpString);
+		[LibraryImport(user32, EntryPoint = "SetWindowTextW", StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool SetWindowText(nint hWnd, string lpString);
 
-		[DllImport(shell32)]
-		internal static extern int SHEmptyRecycleBin(nint hWnd, string pszRootPath, uint dwFlags);
+		[LibraryImport(shell32, EntryPoint = "SHEmptyRecycleBinW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial int SHEmptyRecycleBin(nint hWnd, string pszRootPath, uint dwFlags);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool ShowWindow(nint hWnd, int nCmdShow);
+		[LibraryImport(user32, EntryPoint = "ShowWindow")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool ShowWindow(nint hWnd, int nCmdShow);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool TerminateProcess(nint hProcess, uint uExitCode);
+		[LibraryImport(kernel32, EntryPoint = "TerminateProcess")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool TerminateProcess(nint hProcess, uint uExitCode);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff, int cchBuff, uint wFlags, nint dwhkl);
+		[LibraryImport(user32, StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out] char[] pwszBuff, int cchBuff, uint wFlags, nint dwhkl);
 
-		internal static int ToUnicodeOrAsciiEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff, uint wFlags, nint dwhkl) =>
-		ToUnicodeEx(wVirtKey, wScanCode, lpKeyState, pwszBuff, pwszBuff.Capacity, wFlags, dwhkl);
+		internal static int ToUnicodeOrAsciiEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out] char[] pwszBuff, uint wFlags, nint dwhkl) =>
+		ToUnicodeEx(wVirtKey, wScanCode, lpKeyState, pwszBuff, pwszBuff.Length, wFlags, dwhkl);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool UnhookWindowsHookEx(nint hhk);
+		[LibraryImport(user32, EntryPoint = "UnhookWindowsHookEx")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool UnhookWindowsHookEx(nint hhk);
 
-		[DllImport(version, CharSet = CharSet.Unicode)]
-		internal static extern bool VerQueryValue(byte[] pBlock, string pSubBlock, out string pValue, out uint len);
+		[LibraryImport(version, EntryPoint = "VerQueryValueW", StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool VerQueryValue(byte[] pBlock, string pSubBlock, out string pValue, out uint len);
 
-		[DllImport(winmm, CharSet = CharSet.Unicode)]
-		internal static extern uint waveOutGetVolume(nint hwo, out uint dwVolume);
+		[LibraryImport(winmm, EntryPoint = "waveOutGetVolume")]
+		internal static partial uint waveOutGetVolume(nint hwo, out uint dwVolume);
 
-		[DllImport(winmm, CharSet = CharSet.Unicode)]
-		internal static extern int waveOutSetVolume(nint hwo, uint dwVolume);
+		[LibraryImport(winmm, EntryPoint = "waveOutSetVolume")]
+		internal static partial int waveOutSetVolume(nint hwo, uint dwVolume);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint WindowFromPoint(Point Point);
+		[LibraryImport(user32, EntryPoint = "WindowFromPoint")]
+		internal static partial nint WindowFromPoint(POINT Point);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
-		internal static extern bool WritePrivateProfileString(string lpAppName, string lpKeyName, string lpString, string lpFileName);
+		[LibraryImport(kernel32, EntryPoint = "WritePrivateProfileStringW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool WritePrivateProfileString(string lpAppName, string lpKeyName, string lpString, string lpFileName);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
-		internal static extern bool WritePrivateProfileSection(string lpAppName, string lpString, string lpFileName);
+		[LibraryImport(kernel32, EntryPoint = "WritePrivateProfileSectionW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool WritePrivateProfileSection(string lpAppName, string lpString, string lpFileName);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int SendMessage(nint hwnd, uint msg, int wParam, StringBuilder sb);
+		[LibraryImport(user32, EntryPoint = "SendMessageW", StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial int SendMessage(nint hwnd, uint msg, int wParam, [Out] char[] chars);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern nint GetAncestor(nint hwnd, GetAncestorFlags flags);
+		[LibraryImport(user32, EntryPoint = "GetAncestor")]
+		internal static partial nint GetAncestor(nint hwnd, GetAncestorFlags flags);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool RegisterHotKey(nint hWnd, uint id, KeyModifiers fsModifiers, uint vk);
+		[LibraryImport(user32, EntryPoint = "RegisterHotKey")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool RegisterHotKey(nint hWnd, uint id, KeyModifiers fsModifiers, uint vk);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool UnregisterHotKey(nint hWnd, uint id);
+		[LibraryImport(user32, EntryPoint = "UnregisterHotKey")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool UnregisterHotKey(nint hWnd, uint id);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern bool IsCharAlphaNumeric(char ch);
+		[LibraryImport(user32, EntryPoint = "IsCharAlphaNumericW")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool IsCharAlphaNumeric([MarshalAs(UnmanagedType.U2)] char ch);
 
 		/// <summary>
 		/// Returns the first ancestor of aWnd that isn't itself a child.  aWnd itself is returned if
@@ -2005,13 +2057,13 @@ namespace Keysharp.Core.Windows
 			if (val == 0)
 				return DefaultErrorString;
 
-			var sb = new StringBuilder(val + 1);  // leave room for null-terminator
+			var buffer = new char[val + 1];  // leave room for null-terminator
 			nint ptr = 0;
 
-			if (SendMessageTimeout(hwnd, WM_GETTEXT, sb.Capacity, sb, SendMessageTimeoutFlags.SMTO_ABORTIFHUNG, timeout, out ptr) == 0)
+			if (SendMessageTimeout(hwnd, WM_GETTEXT, buffer.Length, buffer, SendMessageTimeoutFlags.SMTO_ABORTIFHUNG, timeout, out ptr) == 0)
 				return DefaultErrorString;
 
-			return sb.ToString();
+			return new string(buffer, 0, unchecked((int)ptr));
 		}
 
 		internal static bool ControlSetTab(nint hwnd, int tabIndex)
@@ -2061,54 +2113,65 @@ namespace Keysharp.Core.Windows
 			return true;
 		}
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool GetStringTypeEx(uint Locale, uint dwInfoType, string lpSrcStr, int cchSrc, [Out] ushort[] lpCharType);
+		[LibraryImport(kernel32, EntryPoint = "GetStringTypeExW", StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool GetStringTypeEx(uint Locale, uint dwInfoType, string lpSrcStr, int cchSrc, [Out] ushort[] lpCharType);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool GetExitCodeThread(nint hThread, out uint lpExitCode);
+		[LibraryImport(kernel32, EntryPoint = "GetExitCodeThread")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool GetExitCodeThread(nint hThread, out uint lpExitCode);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool SetThreadPriority(nint hThread, int priority);
+		[LibraryImport(kernel32, EntryPoint = "SetThreadPriority")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool SetThreadPriority(nint hThread, int priority);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern nint OpenProcess(ProcessAccessTypes desiredAccess, bool inheritHandle, uint processId);
+		[LibraryImport(kernel32, EntryPoint = "OpenProcess")]
+		internal static partial nint OpenProcess(ProcessAccessTypes desiredAccess, [MarshalAs(UnmanagedType.Bool)] bool inheritHandle, uint processId);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool QueryFullProcessImageName(nint hProcess, uint dwFlags, [Out, MarshalAs(UnmanagedType.LPTStr)] StringBuilder lpExeName, ref uint lpdwSize);
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern nint VirtualAlloc(nint lpAddress, nint dwSize, uint flAllocationType, uint flProtect);
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool VirtualFree(nint lpAddress, nint dwSize, uint dwFreeType);
+		[LibraryImport(kernel32, EntryPoint = "QueryFullProcessImageNameW", StringMarshalling = StringMarshalling.Utf16)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static unsafe partial bool QueryFullProcessImageName(nint hProcess, uint dwFlags, [Out] char[] lpExeName, ref uint lpdwSize);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern nint VirtualAllocEx(nint hProcess, nint address, uint size, VirtualAllocExTypes allocationType, AccessProtectionFlags flags);
+		[LibraryImport(kernel32, EntryPoint = "VirtualAlloc")]
+		internal static partial nint VirtualAlloc(nint lpAddress, nint dwSize, uint flAllocationType, uint flProtect);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool VirtualFreeEx(nint hProcess, nint address, uint size, VirtualAllocExTypes dwFreeType);
+		[LibraryImport(kernel32, EntryPoint = "VirtualFree")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool VirtualFree(nint lpAddress, nint dwSize, uint dwFreeType);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool ReadProcessMemory(nint hProcess, nint baseAddress, byte[] buffer, uint dwSize, out uint numberOfBytesRead);
+		[LibraryImport(kernel32, EntryPoint = "VirtualAllocEx")]
+		internal static partial nint VirtualAllocEx(nint hProcess, nint address, uint size, VirtualAllocExTypes allocationType, AccessProtectionFlags flags);
 
-		[DllImport(kernel32, CharSet = CharSet.Unicode)]
-		internal static extern bool WriteProcessMemory(nint hProcess, nint lpBaseAddress, nint lpBuffer, int nSize, out nint lpNumberOfBytesWritten);
+		[LibraryImport(kernel32, EntryPoint = "VirtualFreeEx")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool VirtualFreeEx(nint hProcess, nint address, uint size, VirtualAllocExTypes dwFreeType);
 
-		[DllImport(gdi32, CharSet = CharSet.Unicode)]
-		internal static extern nint CreateEllipticRgn(int nLeftRect, int nTopRect, int nRightRect, int nBottomRect);
+		[LibraryImport(kernel32, EntryPoint = "ReadProcessMemory")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool ReadProcessMemory(nint hProcess, nint baseAddress, byte[] buffer, uint dwSize, out uint numberOfBytesRead);
 
-		[DllImport(gdi32, CharSet = CharSet.Unicode)]
-		internal static extern nint CreateRoundRectRgn(int x1, int y1, int x2, int y2, int cx, int cy);
+		[LibraryImport(kernel32, EntryPoint = "WriteProcessMemory")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool WriteProcessMemory(nint hProcess, nint lpBaseAddress, nint lpBuffer, int nSize, out nint lpNumberOfBytesWritten);
 
-		[DllImport(gdi32, CharSet = CharSet.Unicode)]
-		internal static extern nint CreateRectRgn(int nLeftRect, int nTopRect, int nRightRect, int nBottomRect);
+		[LibraryImport(gdi32, EntryPoint = "CreateEllipticRgn")]
+		internal static partial nint CreateEllipticRgn(int nLeftRect, int nTopRect, int nRightRect, int nBottomRect);
 
-		[DllImport(gdi32, CharSet = CharSet.Unicode)]
-		internal static extern nint CreatePolygonRgn(POINT[] lppt, int cPoints, int fnPolyFillMode);
+		[LibraryImport(gdi32, EntryPoint = "CreateRoundRectRgn")]
+		internal static partial nint CreateRoundRectRgn(int x1, int y1, int x2, int y2, int cx, int cy);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int SetWindowRgn(nint hWnd, nint hRgn, bool bRedraw);
+		[LibraryImport(gdi32, EntryPoint = "CreateRectRgn")]
+		internal static partial nint CreateRectRgn(int nLeftRect, int nTopRect, int nRightRect, int nBottomRect);
 
-		[DllImport(gdi32, CharSet = CharSet.Unicode)]
-		internal static extern bool DeleteObject(nint hObject);
+		[LibraryImport(gdi32, EntryPoint = "CreatePolygonRgn")]
+		internal static partial nint CreatePolygonRgn(POINT[] lppt, int cPoints, int fnPolyFillMode);
+
+		[LibraryImport(user32, EntryPoint = "SetWindowRgn")]
+		internal static partial int SetWindowRgn(nint hWnd, nint hRgn, [MarshalAs(UnmanagedType.Bool)] bool bRedraw);
+
+		[LibraryImport(gdi32, EntryPoint = "DeleteObject")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static partial bool DeleteObject(nint hObject);
 
 		internal delegate bool _EnumWindowsProc(nint hwnd, int lParam);//Add an underscore to this name because some sample programs use EnumWindowsProc as a function name.
 
@@ -2118,13 +2181,14 @@ namespace Keysharp.Core.Windows
 
 		internal delegate nint PlaybackProc(int nCode, nint wParam, ref EventMsg lParam);
 
-		[DllImport(user32, CharSet = CharSet.Unicode)]
-		internal static extern int GetSystemMetrics(SystemMetric smIndex);
+		[LibraryImport(user32, EntryPoint = "GetSystemMetrics")]
+		internal static partial int GetSystemMetrics(SystemMetric smIndex);
 
-		[DllImport(psapi, CharSet = CharSet.Unicode, SetLastError = true)]
-		internal static extern uint GetProcessImageFileName(nint hProcess, [Out, MarshalAs(UnmanagedType.LPTStr)] StringBuilder lpExeName, uint nSize);
-		[DllImport(kernel32, CharSet = CharSet.Auto, SetLastError = true)]
-		internal static extern uint QueryDosDevice(string lpDeviceName, StringBuilder lpTargetPath, uint ucchMax);
+		[LibraryImport(psapi, EntryPoint = "GetProcessImageFileNameW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial uint GetProcessImageFileName(nint hProcess, [Out] char[] lpExeName, uint nSize);
+
+		[LibraryImport(kernel32, EntryPoint = "QueryDosDeviceW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+		internal static partial uint QueryDosDevice(string lpDeviceName, [Out] char[] lpTargetPath, uint ucchMax);
 	}
 }
 #endif

--- a/Keysharp.Core/Windows/WindowsKeyboardMouseSender.cs
+++ b/Keysharp.Core/Windows/WindowsKeyboardMouseSender.cs
@@ -45,7 +45,7 @@ namespace Keysharp.Core.Windows
 		internal KeyEventTypes prevEventType;
 		internal uint prevVK;
 		// Tracks this script's own lifetime/persistent modifiers (the ones it caused to be persistent and thus is responsible for tracking).
-		internal Point sendInputCursorPos;
+		internal POINT sendInputCursorPos;
 
 		internal nint targetKeybdLayout;
 		// Set by SendKeys() for use by the functions it calls directly and indirectly.
@@ -162,11 +162,11 @@ namespace Keysharp.Core.Windows
 
 			if (oldLayout != 0)
 			{
-				var sb = new StringBuilder();
+				var chars = new char[16];
 
-				if (GetKeyboardLayoutName(sb))
+				if (GetKeyboardLayoutName(chars))
 				{
-					using (var key = Registry.LocalMachine.OpenSubKey($"SYSTEM\\CurrentControlSet\\Control\\Keyboard Layouts\\{sb}"))
+					using (var key = Registry.LocalMachine.OpenSubKey($"SYSTEM\\CurrentControlSet\\Control\\Keyboard Layouts\\{new string(chars, 0, System.Array.IndexOf(chars, '\0'))}"))
 					{
 						if (key != null)
 						{
@@ -1030,7 +1030,7 @@ namespace Keysharp.Core.Windows
 
 			// The playback mode returned from above doesn't need these flags added because they're ignored for clicks:
 			eventFlags |= (uint)MOUSEEVENTF.MOVE | (uint)MOUSEEVENTF.ABSOLUTE;//Done here for caller, for easier maintenance.
-			Point cursor_pos;
+			POINT cursor_pos;
 
 			if (moveOffset)  // We're moving the mouse cursor relative to its current position.
 			{


### PR DESCRIPTION
1. Largest change is replacing most `[DllImport]` with `[LibraryImport]` as recommended by the [best practices](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/best-practices) article. This resulted in some other modifications as well such as replacing some StringBuilders with char[] (likely resulting in better performance as well), or replacing Point with POINT structures because the former is not blittable. 
Unfortunately the performance benefits of this large change are not amazing, from my testing about 5% or so.
2. GUI position and size should be "saved" if multiple calls to `Gui.Show` are made and only the first one used (unless explicitly overridden by the user with new values).
3. Fixed a bug with `Sleep(0)` which resulted in larger sleeps than expected.
4. Added a quick-path for window matching if an ahk_id was provided, in which case `AllWindows` does not need to be enumerated. 
5. Rounded some DPI-adjusted numbers up. Likely it's better to round all such calculations up to avoid accidental cropping of GUI content etc. 
6. `Map.Set` was fixed to return the map.