### PR TITLE
Guitests.ks fixes

### DIFF
--- a/Keysharp.Core/Common/Images/ImageHelper.cs
+++ b/Keysharp.Core/Common/Images/ImageHelper.cs
@@ -166,21 +166,16 @@
 					}
 					else if (ext == ".ico")
 					{
-						Icon ico = null;
+						if (w > 0 && h < 0) h = w;
+						if (h > 0 && w < 0) w = h;
 
-#if WINDOWS
-						// If a size was requested, load a sized HICON directly from the .ico file.
-						if (w > 0 || h > 0)
-							ico = ExtractIconWithSizeFromIco(filename, w, h);
+						Icon ico = (w <= 0 || h <= 0) ? new Icon(filename) : new Icon(filename, w, h);
 
-						if (ico == null)				
-#endif
-						ico = new Icon(filename);
 						var icos = GuiHelper.SplitIcon(ico);
 
-						if (w > 0 && h > 0)
+						if (w > 0 || h > 0)
 						{
-							var tempIcoBmp = icos.FirstOrDefault(tempico => tempico.Item1.Width == w && tempico.Item1.Height == h);
+							var tempIcoBmp = icos.FirstOrDefault(tempico => (w <= 0 || tempico.Item1.Width == w) && (h <= 0 || tempico.Item1.Height == h));
 							var tempIco = tempIcoBmp.Item1;
 
 							if (tempIco == null)
@@ -209,13 +204,9 @@
 						}
 
 						if (w > 0 || h > 0)
-						{
 							bmp = ResizeBitmap(bmp, w, h);
-						}
 						else if (bmp.Size != SystemInformation.IconSize)
-						{
 							bmp = bmp.Resize(SystemInformation.IconSize.Width, SystemInformation.IconSize.Height);
-						}
 					}
 					else if (ext == ".cur")
 					{
@@ -252,8 +243,8 @@
 			if (w <= 0 && h <= 0)
 				return bmp;
 
-			if (w <= 0) w = h > 0 ? h : bmp.Width;
-			if (h <= 0) h = w > 0 ? w : bmp.Height;
+			if (w <= 0) w = h > 0 && w != 0 ? h : bmp.Width;
+			if (h <= 0) h = w > 0 && h != 0 ? w : bmp.Height;
 
 			if (bmp.Width != w || bmp.Height != h)
 				bmp = bmp.Resize(w, h);
@@ -262,27 +253,6 @@
 		}
 
 #if WINDOWS
-		internal static Icon ExtractIconWithSizeFromIco(string path, int w, int h)
-		{
-			// Normalize target size (icons are square)
-			if (w <= 0 && h > 0) w = h;
-			if (h <= 0 && w > 0) h = w;
-			if (w <= 0 || h <= 0)
-			{
-				w = SystemInformation.IconSize.Width;
-				h = SystemInformation.IconSize.Height;
-			}
-
-			var hicon = WindowsAPI.LoadImage(
-				0,
-				path,
-				WindowsAPI.IMAGE_ICON,
-				w, h,
-				WindowsAPI.LR_LOADFROMFILE | WindowsAPI.LR_CREATEDIBSECTION);
-
-			return hicon != 0 ? Icon.FromHandle(hicon) : null;
-		}
-
 		internal static Icon ExtractIconWithSizeFromModule(string path, int index, int w, int h)
 		{
 			if (w <= 0 && h > 0) w = h;

--- a/Keysharp.Tests/Code/Gui/guitest.ks
+++ b/Keysharp.Tests/Code/Gui/guitest.ks
@@ -923,7 +923,7 @@ CZ_Text3 := MyGui.Add("Text", "xc+10 y+5", "Edit control testing")
 CZ_Text3.SetFont("s8 CBlue")
 
 CZ_Edit1 := MyGui.Add("Edit", "xc+10 y+5 w160 h100")
-CZ_Edit1.SetCue("Multi-line edit control cue text")
+;CZ_Edit1.SetCue("Multi-line edit control cue text")
 
 ; ┌─────────────────────────────────────────────┐
 ; │  ControlZoo - end of Group One, Column One  │


### PR DESCRIPTION
* Reworked Bitmap.Resize to get CandyProgress working
* Removed ExtractIconWithSizeFromIco because it extracted low-quality icons for some reason, and `new Icon(filename, width, height)` overload exists
* Removed multi-line edit cue banner because apparently it's not working any more and caused lag with WS_EX_COMPOSITED (maybe because I upgraded to Windows 11)